### PR TITLE
feat: bastion instance software updates

### DIFF
--- a/src/bastion/bastion-cloudinit.ts
+++ b/src/bastion/bastion-cloudinit.ts
@@ -20,21 +20,20 @@ write_files:
       
       # Stopping instance in case of any error to prevent it from running forever
       handle_error() {
-        echo "[$now] Error running script. Stopping instance."
+        echo "[$(date)] Error running script. Stopping instance."
         
         /sbin/shutdown -h now
       }
 
       trap handle_error ERR
 
-      now=$(date)
-      echo "[$now] =========="
+      echo "[$(date)] =========="
 
       export AWS_DEFAULT_REGION=$(curl -s http://169.254.169.254/latest/meta-data/placement/region)
 
       bastionInstanceId=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
 
-      echo "[$now] Retrieving last in use tag."
+      echo "[$(date)] Retrieving last in use tag."
       lastInUse=$(aws ec2 describe-instances \
         --instance-ids $bastionInstanceId \
         --query "Reservations[0].Instances[0].Tags[?Key=='${BASTION_INSTANCE_IN_USE_TAG_NAME}'].Value" \
@@ -43,9 +42,9 @@ write_files:
       inUseThreshold=$(date -d "now - 5 minutes" -u +"%Y-%m-%dT%H:%M:%SZ")
 
       if [[ $lastInUse < $inUseThreshold ]]; then
-        echo "[$now] Instance is not in use."
+        echo "[$(date)] Instance is not in use."
         
-        echo "[$now] Retrieving last updated tag."
+        echo "[$(date)] Retrieving last updated tag."
         lastUpdated=$(aws ec2 describe-instances \
           --instance-ids $bastionInstanceId \
           --query "Reservations[0].Instances[0].Tags[?Key=='${BASTION_INSTANCE_UPDATED_TAG_NAME}'].Value" \
@@ -54,27 +53,27 @@ write_files:
         lastUpdatedThreshold=$(date -d "now - 1 day" -u +"%Y-%m-%dT%H:%M:%SZ")
 
         if [[ $lastUpdated < $lastUpdatedThreshold ]]; then
-          echo "[$now] Updating instance."
+          echo "[$(date)] Updating instance."
 
-          echo "[$now] Setting updating tag."
+          echo "[$(date)] Setting updating tag."
           aws ec2 create-tags \
             --resources $bastionInstanceId \
             --tags Key=${BASTION_INSTANCE_UPDATING_TAG_NAME},Value=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-          echo "[$now] Updating packages."
+          echo "[$(date)] Updating packages."
           yum update -y
 
-          echo "[$now] Setting updated tag."
+          echo "[$(date)] Setting updated tag."
           aws ec2 create-tags \
             --resources $bastionInstanceId \
             --tags Key=${BASTION_INSTANCE_UPDATED_TAG_NAME},Value=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
         fi
 
-        echo "[$now] Stopping instance."
+        echo "[$(date)] Stopping instance."
         /sbin/shutdown -h now
       fi
 
-      echo "[$now] Instance is in use."
+      echo "[$(date)] Instance is in use."
 
   - path: /var/log/basti/stop-if-not-used.log
     owner: root:root

--- a/src/bastion/bastion-cloudinit.ts
+++ b/src/bastion/bastion-cloudinit.ts
@@ -83,5 +83,5 @@ write_files:
   - path: /etc/cron.d/stop-if-not-used
     owner: root:root
     permissions: "0444"
-    content: "* * * * * root /bin/bash /opt/basti/stop-if-not-used.sh &>> /var/log/basti/stop-if-not-used.log\\n"
+    content: "* * * * * root flock -xn /var/lock/stop-if-not-used.lock -c /opt/basti/stop-if-not-used.sh &>> /var/log/basti/stop-if-not-used.log\\n"
 `;

--- a/src/bastion/bastion-cloudinit.ts
+++ b/src/bastion/bastion-cloudinit.ts
@@ -1,4 +1,8 @@
-import { BASTION_INSTANCE_IN_USE_TAG_NAME } from './bastion.js';
+import {
+  BASTION_INSTANCE_IN_USE_TAG_NAME,
+  BASTION_INSTANCE_UPDATED_TAG_NAME,
+  BASTION_INSTANCE_UPDATING_TAG_NAME,
+} from './bastion.js';
 
 export const BASTION_INSTANCE_CLOUD_INIT = `
 #cloud-config
@@ -11,13 +15,26 @@ write_files:
     permissions: "0544"
     content: |
       #!/bin/bash
+      
       set -e;
+      
+      # Stopping instance in case of any error to prevent it from running forever
+      handle_error() {
+        echo "[$now] Error running script. Stopping instance."
+        
+        /sbin/shutdown -h now
+      }
+
+      trap handle_error ERR
+
+      now=$(date)
+      echo "[$now] =========="
 
       export AWS_DEFAULT_REGION=$(curl -s http://169.254.169.254/latest/meta-data/placement/region)
 
       bastionInstanceId=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
-      now=$(date)
 
+      echo "[$now] Retrieving last in use tag."
       lastInUse=$(aws ec2 describe-instances \
         --instance-ids $bastionInstanceId \
         --query "Reservations[0].Instances[0].Tags[?Key=='${BASTION_INSTANCE_IN_USE_TAG_NAME}'].Value" \
@@ -26,7 +43,34 @@ write_files:
       inUseThreshold=$(date -d "now - 5 minutes" -u +"%Y-%m-%dT%H:%M:%SZ")
 
       if [[ $lastInUse < $inUseThreshold ]]; then
-        echo "[$now] Instance is not in use. Shutting down."
+        echo "[$now] Instance is not in use."
+        
+        echo "[$now] Retrieving last updated tag."
+        lastUpdated=$(aws ec2 describe-instances \
+          --instance-ids $bastionInstanceId \
+          --query "Reservations[0].Instances[0].Tags[?Key=='${BASTION_INSTANCE_UPDATED_TAG_NAME}'].Value" \
+          --output text
+        )
+        lastUpdatedThreshold=$(date -d "now - 1 day" -u +"%Y-%m-%dT%H:%M:%SZ")
+
+        if [[ $lastUpdated < $lastUpdatedThreshold ]]; then
+          echo "[$now] Updating instance."
+
+          echo "[$now] Setting updating tag."
+          aws ec2 create-tags \
+            --resources $bastionInstanceId \
+            --tags Key=${BASTION_INSTANCE_UPDATING_TAG_NAME},Value=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          echo "[$now] Updating packages."
+          yum update -y
+
+          echo "[$now] Setting updated tag."
+          aws ec2 create-tags \
+            --resources $bastionInstanceId \
+            --tags Key=${BASTION_INSTANCE_UPDATED_TAG_NAME},Value=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+        fi
+
+        echo "[$now] Stopping instance."
         /sbin/shutdown -h now
       fi
 

--- a/src/bastion/bastion.ts
+++ b/src/bastion/bastion.ts
@@ -1,3 +1,5 @@
+import { InstanceStateName } from '@aws-sdk/client-ec2';
+
 import { AwsEc2Instance } from '../aws/ec2/types/aws-ec2-instance.js';
 
 export interface Bastion {
@@ -5,14 +7,13 @@ export interface Bastion {
 
   instance: AwsEc2Instance;
 
+  state: BastionState;
+
   securityGroupId: string;
   securityGroupName: string;
 }
 
-export interface BastionState {
-  id: string;
-  instance: AwsEc2Instance;
-}
+export type BastionState = InstanceStateName | 'updating';
 
 export const BASTION_INSTANCE_NAME_PREFIX = 'basti-instance';
 export const BASTION_INSTANCE_ROLE_NAME_PREFIX = BASTION_INSTANCE_NAME_PREFIX;

--- a/src/bastion/bastion.ts
+++ b/src/bastion/bastion.ts
@@ -23,3 +23,5 @@ export const BASTION_INSTANCE_PROFILE_PATH = BASTION_INSTANCE_ROLE_PATH;
 
 export const BASTION_INSTANCE_ID_TAG_NAME = 'basti:id';
 export const BASTION_INSTANCE_IN_USE_TAG_NAME = 'basti:in-use';
+export const BASTION_INSTANCE_UPDATING_TAG_NAME = 'basti:updating';
+export const BASTION_INSTANCE_UPDATED_TAG_NAME = 'basti:updated';

--- a/src/bastion/create-bastion-role.ts
+++ b/src/bastion/create-bastion-role.ts
@@ -13,6 +13,7 @@ export interface CreateBastionRoleInput {
 
 export interface CreateBastionInlinePoliciesInput {
   bastionRoleName: string;
+  bastionInstanceId: string;
 }
 
 export async function createBastionRole({
@@ -27,6 +28,7 @@ export async function createBastionRole({
 
 export async function createBastionRoleInlinePolicies({
   bastionRoleName,
+  bastionInstanceId,
 }: CreateBastionInlinePoliciesInput): Promise<void> {
   await createIamInlinePolicy({
     roleName: bastionRoleName,
@@ -37,7 +39,7 @@ export async function createBastionRoleInlinePolicies({
   await createIamInlinePolicy({
     roleName: bastionRoleName,
     policyName: 'ec2-instance-access',
-    policyDocument: getAwsInstanceAccessPolicy(),
+    policyDocument: getAwsInstanceAccessPolicy(bastionInstanceId),
   });
 }
 
@@ -66,7 +68,7 @@ function getSessionManagerAccessPolicy(): string {
   });
 }
 
-function getAwsInstanceAccessPolicy(): string {
+function getAwsInstanceAccessPolicy(bastionInstanceId: string): string {
   return JSON.stringify({
     Version: '2012-10-17',
     Statement: [
@@ -74,6 +76,11 @@ function getAwsInstanceAccessPolicy(): string {
         Effect: 'Allow',
         Action: ['ec2:DescribeInstances'],
         Resource: '*', // ec2:DescribeInstances does not support resource-level permissions
+      },
+      {
+        Effect: 'Allow',
+        Action: ['ec2:CreateTags'],
+        Resource: `arn:aws:ec2:*:*:instance/${bastionInstanceId}`,
       },
     ],
   });

--- a/src/bastion/create-bastion.ts
+++ b/src/bastion/create-bastion.ts
@@ -62,14 +62,18 @@ export async function createBastion({
     hooks
   );
 
-  await createBastionRoleInlinePolicies(bastionRole.name, hooks);
-
   const bastionInstance = await createBastionInstance(
     bastionId,
     bastionImageId,
     bastionRole,
     subnetId,
     bastionSecurityGroup,
+    hooks
+  );
+
+  await createBastionRoleInlinePolicies(
+    bastionRole.name,
+    bastionInstance.id,
     hooks
   );
 
@@ -127,12 +131,14 @@ async function createBastionRole(
 
 async function createBastionRoleInlinePolicies(
   bastionRoleName: string,
+  bastionInstanceId: string,
   hooks?: CreateBastionHooks
 ): Promise<void> {
   try {
     hooks?.onCreatingInlinePolicies?.();
     await bastionRoleOps.createBastionRoleInlinePolicies({
       bastionRoleName,
+      bastionInstanceId,
     });
     hooks?.onInlinePoliciesCreated?.();
   } catch (error) {

--- a/src/bastion/create-bastion.ts
+++ b/src/bastion/create-bastion.ts
@@ -1,3 +1,5 @@
+import { InstanceStateName } from '@aws-sdk/client-ec2';
+
 import { createEc2Instance } from '../aws/ec2/create-ec2-instance.js';
 import { createSecurityGroup } from '../aws/ec2/create-security-group.js';
 import { AwsEc2Instance } from '../aws/ec2/types/aws-ec2-instance.js';
@@ -75,6 +77,8 @@ export async function createBastion({
     id: bastionId,
 
     instance: bastionInstance,
+
+    state: InstanceStateName.running,
 
     securityGroupId: bastionSecurityGroup.id,
     securityGroupName: bastionSecurityGroup.name,

--- a/src/bastion/get-bastion.ts
+++ b/src/bastion/get-bastion.ts
@@ -1,5 +1,8 @@
 import { InstanceStateName } from '@aws-sdk/client-ec2';
 
+import { AwsEc2Instance } from '#src/aws/ec2/types/aws-ec2-instance.js';
+import { AwsSecurityGroupIdentifier } from '#src/aws/ec2/types/aws-security-group.js';
+
 import { getEc2Instances } from '../aws/ec2/get-ec2-instances.js';
 import { ManagedResourceTypes } from '../common/resource-type.js';
 import {
@@ -9,14 +12,18 @@ import {
 
 import {
   Bastion,
+  BastionState,
   BASTION_INSTANCE_ID_TAG_NAME,
   BASTION_INSTANCE_SECURITY_GROUP_NAME_PREFIX,
+  BASTION_INSTANCE_UPDATING_TAG_NAME,
 } from './bastion.js';
 
 export interface GetBastionInput {
   bastionId?: string;
   vpcId?: string;
 }
+
+const BASTION_INSTANCE_UPDATING_TIMEOUT = 1000 * 60 * 10;
 
 export async function getBastion({
   bastionId,
@@ -42,6 +49,22 @@ export async function getBastion({
     return;
   }
 
+  const id = getBastionId(instance);
+
+  const state = getBastionInstanceState(instance);
+
+  const securityGroup = getBastionInstanceSecurityGroup(instance);
+
+  return {
+    id,
+    instance,
+    state,
+    securityGroupId: securityGroup.id,
+    securityGroupName: securityGroup.name,
+  };
+}
+
+function getBastionId(instance: AwsEc2Instance): string {
   const id = instance.tags[BASTION_INSTANCE_ID_TAG_NAME];
   if (id === undefined) {
     throw new UnexpectedStateError(
@@ -52,7 +75,34 @@ export async function getBastion({
       )
     );
   }
+  return id;
+}
 
+function getBastionInstanceState(instance: AwsEc2Instance): BastionState {
+  const now = new Date();
+
+  const updatingTime = parseTimeTag(
+    instance,
+    BASTION_INSTANCE_UPDATING_TAG_NAME
+  );
+
+  if (
+    // Instance is running
+    instance.state === InstanceStateName.running &&
+    // It started updating
+    updatingTime !== undefined &&
+    // The update started recently
+    now.getTime() - updatingTime.getTime() < BASTION_INSTANCE_UPDATING_TIMEOUT
+  ) {
+    return 'updating';
+  }
+
+  return instance.state;
+}
+
+function getBastionInstanceSecurityGroup(
+  instance: AwsEc2Instance
+): AwsSecurityGroupIdentifier {
   const securityGroup = instance.securityGroups.find(group =>
     group.name.startsWith(BASTION_INSTANCE_SECURITY_GROUP_NAME_PREFIX)
   );
@@ -65,11 +115,28 @@ export async function getBastion({
       )
     );
   }
+  return securityGroup;
+}
 
-  return {
-    id,
-    instance,
-    securityGroupId: securityGroup.id,
-    securityGroupName: securityGroup.name,
-  };
+function parseTimeTag(
+  instance: AwsEc2Instance,
+  tagName: string
+): Date | undefined {
+  const vagValue = instance.tags[tagName];
+
+  if (vagValue === undefined) {
+    return;
+  }
+
+  try {
+    return new Date(vagValue);
+  } catch {
+    throw new UnexpectedStateError(
+      new ResourceDamagedError(
+        ManagedResourceTypes.BASTION_INSTANCE,
+        instance.id,
+        `"${tagName}" tag has invalid value`
+      )
+    );
+  }
 }

--- a/src/cli/commands/connect/ensure-bastion-running.ts
+++ b/src/cli/commands/connect/ensure-bastion-running.ts
@@ -26,6 +26,10 @@ export async function ensureBastionRunning({
           cli.progressStart(
             `Bastion instance is stopping. Waiting instance to stop`
           ),
+        onWaitingInstanceToUpdate: () =>
+          cli.progressStart(
+            `Bastion instance is updating. This may take a few minutes`
+          ),
         onStartingInstance: () =>
           cli.progressStart(
             `Bastion instance is stopped. Starting bastion instance`

--- a/src/cli/commands/init/allow-target-access.ts
+++ b/src/cli/commands/init/allow-target-access.ts
@@ -50,9 +50,9 @@ export async function allowTargetAccess({
       },
     });
     cli.success(
-      `The target has been initialized to use with Basti. Use ${fmt.code(
+      `The target has been initialized to use with Basti. It's recommended to give AWS a few minutes to propagate the changes before connecting with the ${fmt.code(
         'basti connect'
-      )} to establish a connection`
+      )} command`
     );
   } catch (error) {
     subCli.progressFailure();


### PR DESCRIPTION
#### Summary

This PR makes Basti EC2 instance update software once a day when shutting down. `yum update` is used for software updates and is followed with instance shutdown, which applies all the patches requiring rebooting.

#### References

#24 

#### Context

I used AWS Inspector as a source of suggestions for improving the secureness of the instance. Inspector didn't find any network reachability vulnerabilities and only suggested updating core packages. 

This improvement should not only improve the solution security but also prevent tools like AWS Inspector and Vanta (which uses Inspector under the hood) from complaining about the EC2 instance.
