### PR TITLE
feat: add aws-profile and aws-region flags

### DIFF
--- a/src/aws/common/aws-client.ts
+++ b/src/aws/common/aws-client.ts
@@ -1,26 +1,39 @@
-type ClientConstructor<T> = new (input: { region: string }) => T;
+export interface AwsClientConfiguration {
+  region?: string;
+  profile?: string;
+}
+export type AwsClientConstructor<T> = new (config: AwsClientConfiguration) => T;
 
-interface Client {
+export interface RawAwsClient {
   send: (...args: any[]) => Promise<any>;
 }
 
-type ErrorHandler<TResponse> = (
+export type AwsClientErrorHandler<TResponse> = (
   handler: () => Promise<TResponse>
 ) => Promise<TResponse>;
 
-export class AwsClient<T extends Client> {
+// The global config is expected to be overriden on the application startup before
+// the command dynamic import happens and any AWS client is instantiated.
+const AWS_CLIENT_GLOBAL_CONFIGURATION: AwsClientConfiguration = {};
+
+export const setAwsClientGlobalConfiguration = (
+  config: AwsClientConfiguration
+): void => {
+  Object.assign(AWS_CLIENT_GLOBAL_CONFIGURATION, config);
+};
+
+export class AwsClient<T extends RawAwsClient> {
   public readonly client: T;
-  private readonly errorHandler?: ErrorHandler<ReturnType<T['send']>>;
+  private readonly errorHandler?: AwsClientErrorHandler<ReturnType<T['send']>>;
 
   constructor({
     Client,
     errorHandler,
   }: {
-    Client: ClientConstructor<T>;
-    errorHandler?: ErrorHandler<ReturnType<T['send']>>;
+    Client: AwsClientConstructor<T>;
+    errorHandler?: AwsClientErrorHandler<ReturnType<T['send']>>;
   }) {
-    // @ts-expect-error
-    this.client = new Client({});
+    this.client = new Client(AWS_CLIENT_GLOBAL_CONFIGURATION);
     this.errorHandler = errorHandler;
   }
 

--- a/src/aws/common/aws-client.ts
+++ b/src/aws/common/aws-client.ts
@@ -12,18 +12,14 @@ export type AwsClientErrorHandler<TResponse> = (
   handler: () => Promise<TResponse>
 ) => Promise<TResponse>;
 
-// The global config is expected to be overriden on the application startup before
-// the command dynamic import happens and any AWS client is instantiated.
-const AWS_CLIENT_GLOBAL_CONFIGURATION: AwsClientConfiguration = {};
-
-export const setAwsClientGlobalConfiguration = (
-  config: AwsClientConfiguration
-): void => {
-  Object.assign(AWS_CLIENT_GLOBAL_CONFIGURATION, config);
-};
-
 export class AwsClient<T extends RawAwsClient> {
+  // The global config is expected to be overriden on the application startup before
+  // the command dynamic import happens and any AWS client is instantiated.
+  private static readonly AWS_CLIENT_GLOBAL_CONFIGURATION: AwsClientConfiguration =
+    {};
+
   public readonly client: T;
+
   private readonly errorHandler?: AwsClientErrorHandler<ReturnType<T['send']>>;
 
   constructor({
@@ -33,8 +29,12 @@ export class AwsClient<T extends RawAwsClient> {
     Client: AwsClientConstructor<T>;
     errorHandler?: AwsClientErrorHandler<ReturnType<T['send']>>;
   }) {
-    this.client = new Client(AWS_CLIENT_GLOBAL_CONFIGURATION);
+    this.client = new Client(AwsClient.AWS_CLIENT_GLOBAL_CONFIGURATION);
     this.errorHandler = errorHandler;
+  }
+
+  static setGlobalConfiguration(config: AwsClientConfiguration): void {
+    Object.assign(AwsClient.AWS_CLIENT_GLOBAL_CONFIGURATION, config);
   }
 
   send: T['send'] = async (...args) =>

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -4,7 +4,7 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 import { setUpDebugMode } from '#src/common/debug.js';
-import { setAwsClientGlobalConfiguration } from '#src/aws/common/aws-client.js';
+import { AwsClient } from '#src/aws/common/aws-client.js';
 
 import { handleAsyncErrors, withErrorHandling } from './error/handle-error.js';
 import { conflictingOptions } from './yargs/conflicting-options-check.js';
@@ -62,7 +62,7 @@ void yargs(hideBin(process.argv))
       const { rdsInstance, rdsCluster, customTargetVpc, bastionSubnet } =
         options;
 
-      setAwsClientGlobalConfiguration(getAwsClientOptions(options));
+      AwsClient.setGlobalConfiguration(getAwsClientOptions(options));
       const { handleInit } = await import('./commands/init/init.js');
 
       const target =
@@ -140,7 +140,7 @@ void yargs(hideBin(process.argv))
         localPort,
       } = options;
 
-      setAwsClientGlobalConfiguration(getAwsClientOptions(options));
+      AwsClient.setGlobalConfiguration(getAwsClientOptions(options));
       const { handleConnect } = await import('./commands/connect/connect.js');
 
       const target =
@@ -181,7 +181,7 @@ void yargs(hideBin(process.argv))
     withErrorHandling(async options => {
       const { confirm } = options;
 
-      setAwsClientGlobalConfiguration(getAwsClientOptions(options));
+      AwsClient.setGlobalConfiguration(getAwsClientOptions(options));
       const { handleCleanup } = await import('./commands/cleanup/cleanup.js');
 
       return await handleCleanup({ confirm });

--- a/src/cli/yargs/aws-client-options.ts
+++ b/src/cli/yargs/aws-client-options.ts
@@ -1,0 +1,31 @@
+import { AwsClientConfiguration } from '#src/aws/common/aws-client.js';
+
+export const YARGS_AWS_CLIENT_OPTIONS = {
+  AWS_PROFILE: [
+    'aws-profile',
+    {
+      type: 'string',
+      description: 'AWS CLI profile to use',
+    },
+  ],
+  AWS_REGION: [
+    'aws-region',
+    {
+      type: 'string',
+      description: 'AWS region to use',
+    },
+  ],
+} as const;
+
+export function getAwsClientOptions({
+  awsProfile,
+  awsRegion,
+}: {
+  awsProfile?: string;
+  awsRegion?: string;
+}): AwsClientConfiguration {
+  return {
+    profile: awsProfile,
+    region: awsRegion,
+  };
+}


### PR DESCRIPTION
### Summary

This PR adds two new CLI options:

1. `--aws-profile` - Indicates an AWS CLI profile to use
2. `--aws-region` - Indicates an AWS region to use

The PR also makes commands being imported dynamically. This improves application startup time:

* `basti -h` before: ~1.4s
* `basti -h` after: ~0.5s
* 
This improvement compensates for the increased complexity of the `AwsClient`s initialization and application initialization in general.

### References
closes https://github.com/BohdanPetryshyn/basti/issues/12
closes https://github.com/BohdanPetryshyn/basti/issues/15