### PR TITLE
feat: predefined options set in configuration file

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,10 @@
       "error",
       { "ignoreDeclarationMerge": true }
     ],
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      { "prefer": "type-imports" }
+    ],
     "import/order": [
       "error",
       {

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ dist
 .history
 .DS_Store
 .build-deps-tmp
-.bastirc.yaml
+basti.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 .history
 .DS_Store
 .build-deps-tmp
+.bastirc.yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "basti",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "basti",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-ec2": "3.231.0",
@@ -14,10 +14,12 @@
         "@aws-sdk/client-rds": "3.231.0",
         "@aws-sdk/client-ssm": "3.231.0",
         "chalk": "5.0.1",
+        "cosmiconfig": "^8.1.3",
         "inquirer": "9.0.0",
         "ora": "6.1.2",
-        "yargs": "17.5.1",
-        "zod": "3.17.3"
+        "yargs": "^17.7.2",
+        "zod": "^3.18.0",
+        "zod-validation-error": "^1.3.0"
       },
       "bin": {
         "basti": "bin/run.js"
@@ -1213,7 +1215,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
       "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.18.6"
       },
@@ -1225,7 +1226,6 @@
       "version": "7.19.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
       "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1234,7 +1234,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
       "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
@@ -1248,7 +1247,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -1260,7 +1258,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1274,7 +1271,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -1282,14 +1278,12 @@
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -1298,7 +1292,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -1307,7 +1300,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -1831,8 +1823,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-includes": {
       "version": "3.1.5",
@@ -2063,7 +2054,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2145,13 +2135,16 @@
       }
     },
     "node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/clone": {
@@ -2183,6 +2176,23 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/cosmiconfig": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
+      "integrity": "sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==",
+      "dependencies": {
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -2320,7 +2330,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -3458,7 +3467,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -3618,8 +3626,7 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "node_modules/is-bigint": {
       "version": "1.0.4",
@@ -3902,14 +3909,12 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -3920,8 +3925,7 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -3963,8 +3967,7 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -4328,7 +4331,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -4340,7 +4342,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -4391,7 +4392,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4670,7 +4670,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -5329,26 +5328,26 @@
       "dev": true
     },
     "node_modules/yargs": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "engines": {
         "node": ">=12"
       }
@@ -5375,11 +5374,22 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.3.tgz",
-      "integrity": "sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.18.0.tgz",
+      "integrity": "sha512-gwTm8RfUCe8l9rDwN5r2A17DkAa8Ez4Yl4yXqc5VqeGaXaJahzYYXbTwvhroZi0SNBqTwh/bKm2N0mpCzuw4bA==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-1.3.0.tgz",
+      "integrity": "sha512-4WoQnuWnj06kwKR4A+cykRxFmy+CTvwMQO5ogTXLiVx1AuvYYmMjixh7sbkSsQTr1Fvtss6d5kVz8PGeMPUQjQ==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.18.0"
       }
     }
   },
@@ -6375,7 +6385,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
       "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.18.6"
       }
@@ -6383,14 +6392,12 @@
     "@babel/helper-validator-identifier": {
       "version": "7.19.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
-      "dev": true
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
     },
     "@babel/highlight": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
       "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
@@ -6401,7 +6408,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -6410,7 +6416,6 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -6421,7 +6426,6 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -6429,26 +6433,22 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-          "dev": true
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -6811,8 +6811,7 @@
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "array-includes": {
       "version": "3.1.5",
@@ -6957,8 +6956,7 @@
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "chalk": {
       "version": "5.0.1",
@@ -7012,12 +7010,12 @@
       "integrity": "sha512-ZksGS2xpa/bYkNzN3BAw1wEjsLV/ZKOf/CCrJ/QOBsxx6fOARIkwTutxp1XIOIohi6HKmOFjMoK/XaqDVUpEEw=="
     },
     "cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "requires": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
       }
     },
@@ -7044,6 +7042,17 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "cosmiconfig": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
+      "integrity": "sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==",
+      "requires": {
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0"
+      }
     },
     "create-require": {
       "version": "1.1.1",
@@ -7149,7 +7158,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -7963,7 +7971,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -8077,8 +8084,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "is-bigint": {
       "version": "1.0.4",
@@ -8259,14 +8265,12 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -8274,8 +8278,7 @@
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -8311,8 +8314,7 @@
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "locate-path": {
       "version": "6.0.0",
@@ -8578,7 +8580,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "requires": {
         "callsites": "^3.0.0"
       }
@@ -8587,7 +8588,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -8622,8 +8622,7 @@
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
     "picocolors": {
       "version": "1.0.0",
@@ -8804,8 +8803,7 @@
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
     },
     "restore-cursor": {
       "version": "4.0.0",
@@ -9279,23 +9277,23 @@
       "dev": true
     },
     "yargs": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "requires": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
+        "yargs-parser": "^21.1.1"
       }
     },
     "yargs-parser": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg=="
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
     },
     "yn": {
       "version": "3.1.1",
@@ -9310,9 +9308,15 @@
       "dev": true
     },
     "zod": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.3.tgz",
-      "integrity": "sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg=="
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.18.0.tgz",
+      "integrity": "sha512-gwTm8RfUCe8l9rDwN5r2A17DkAa8Ez4Yl4yXqc5VqeGaXaJahzYYXbTwvhroZi0SNBqTwh/bKm2N0mpCzuw4bA=="
+    },
+    "zod-validation-error": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-1.3.0.tgz",
+      "integrity": "sha512-4WoQnuWnj06kwKR4A+cykRxFmy+CTvwMQO5ogTXLiVx1AuvYYmMjixh7sbkSsQTr1Fvtss6d5kVz8PGeMPUQjQ==",
+      "requires": {}
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "basti": "bin/run.js"
   },
   "scripts": {
-    "start": "npm run build && node bin/run.js",
+    "start": "node bin/run.js",
     "build": "npm run build-src && npm run build-deps",
     "build-src": "tsc",
     "build-src-watch": "tsc --watch",
@@ -53,10 +53,12 @@
     "@aws-sdk/client-rds": "3.231.0",
     "@aws-sdk/client-ssm": "3.231.0",
     "chalk": "5.0.1",
+    "cosmiconfig": "8.1.3",
     "inquirer": "9.0.0",
     "ora": "6.1.2",
-    "yargs": "17.5.1",
-    "zod": "3.17.3"
+    "yargs": "17.7.2",
+    "zod": "3.18.0",
+    "zod-validation-error": "1.3.0"
   },
   "optionalDependencies": {
     "basti-session-manager-binary-darwin-arm64": "1.2.295.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "basti",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Basti is a CLI tool for accessing DB instances and other AWS resources in private networks almost at no cost.",
   "author": "BohdanPetryshyn",
   "homepage": "https://github.com/BohdanPetryshyn/basti#readme",

--- a/src/aws/ec2/create-ec2-instance.ts
+++ b/src/aws/ec2/create-ec2-instance.ts
@@ -8,12 +8,13 @@ import { retry } from '#src/common/retry.js';
 import { handleWaiterError } from '../common/waiter-error.js';
 import { COMMON_WAITER_CONFIG } from '../common/waiter-config.js';
 import { createIamInstanceProfile } from '../iam/create-instance-profile.js';
-import { AwsTag } from '../tags/types.js';
 
 import { AwsInstanceProfileNotFoundError } from './ec2-errors.js';
 import { parseEc2InstanceResponse } from './parse-ec2-response.js';
-import { AwsEc2Instance } from './types/aws-ec2-instance.js';
 import { ec2Client } from './ec2-client.js';
+
+import type { AwsEc2Instance } from './types/aws-ec2-instance.js';
+import type { AwsTag } from '../tags/types.js';
 
 export interface CreateEc2InstanceInput {
   imageId: string;

--- a/src/aws/ec2/create-security-group.ts
+++ b/src/aws/ec2/create-security-group.ts
@@ -1,7 +1,6 @@
 import {
   AuthorizeSecurityGroupIngressCommand,
   CreateSecurityGroupCommand,
-  IpPermission,
   waitUntilSecurityGroupExists,
 } from '@aws-sdk/client-ec2';
 
@@ -9,7 +8,9 @@ import { COMMON_WAITER_CONFIG } from '../common/waiter-config.js';
 import { handleWaiterError } from '../common/waiter-error.js';
 
 import { ec2Client } from './ec2-client.js';
-import {
+
+import type { IpPermission } from '@aws-sdk/client-ec2';
+import type {
   AwsSecurityGroup,
   SecurityGroupIngressRule,
 } from './types/aws-security-group.js';

--- a/src/aws/ec2/get-ec2-instances.ts
+++ b/src/aws/ec2/get-ec2-instances.ts
@@ -1,15 +1,13 @@
-import {
-  DescribeInstancesCommand,
-  Filter,
-  InstanceStateName,
-} from '@aws-sdk/client-ec2';
+import { DescribeInstancesCommand } from '@aws-sdk/client-ec2';
 
 import { getTagFilter } from '../tags/get-tag-filter.js';
-import { AwsTag } from '../tags/types.js';
 
 import { ec2Client } from './ec2-client.js';
 import { parseEc2InstanceResponse } from './parse-ec2-response.js';
-import { AwsEc2Instance } from './types/aws-ec2-instance.js';
+
+import type { AwsTag } from '../tags/types.js';
+import type { Filter, InstanceStateName } from '@aws-sdk/client-ec2';
+import type { AwsEc2Instance } from './types/aws-ec2-instance.js';
 
 export interface GetEc2InstancesInput {
   vpcId?: string;

--- a/src/aws/ec2/get-route-tables.ts
+++ b/src/aws/ec2/get-route-tables.ts
@@ -2,7 +2,8 @@ import { DescribeRouteTablesCommand } from '@aws-sdk/client-ec2';
 
 import { ec2Client } from './ec2-client.js';
 import { parseRouteTableResponse } from './parse-ec2-response.js';
-import { AwsRouteTable } from './types/aws-vpc.js';
+
+import type { AwsRouteTable } from './types/aws-vpc.js';
 
 export interface GetRoutingTableInput {
   subnetId: string;

--- a/src/aws/ec2/get-security-groups.ts
+++ b/src/aws/ec2/get-security-groups.ts
@@ -1,11 +1,13 @@
-import { DescribeSecurityGroupsCommand, Filter } from '@aws-sdk/client-ec2';
+import { DescribeSecurityGroupsCommand } from '@aws-sdk/client-ec2';
 
 import { getTagFilter } from '../tags/get-tag-filter.js';
-import { AwsTag } from '../tags/types.js';
 
 import { ec2Client } from './ec2-client.js';
 import { parseSecurityGroupResponse } from './parse-ec2-response.js';
-import { AwsSecurityGroup } from './types/aws-security-group.js';
+
+import type { AwsTag } from '../tags/types.js';
+import type { Filter } from '@aws-sdk/client-ec2';
+import type { AwsSecurityGroup } from './types/aws-security-group.js';
 
 export interface GetSecurityGroupsInput {
   securityGroupIds?: string[];

--- a/src/aws/ec2/get-subnets.ts
+++ b/src/aws/ec2/get-subnets.ts
@@ -2,7 +2,8 @@ import { DescribeSubnetsCommand } from '@aws-sdk/client-ec2';
 
 import { ec2Client } from './ec2-client.js';
 import { parseSubnetResponse } from './parse-ec2-response.js';
-import { AwsSubnet } from './types/aws-vpc.js';
+
+import type { AwsSubnet } from './types/aws-vpc.js';
 
 export interface GetSubnetsInput {
   vpcId: string;

--- a/src/aws/ec2/get-vpcs.ts
+++ b/src/aws/ec2/get-vpcs.ts
@@ -2,7 +2,8 @@ import { DescribeVpcsCommand } from '@aws-sdk/client-ec2';
 
 import { ec2Client } from './ec2-client.js';
 import { parseVpcResponse } from './parse-ec2-response.js';
-import { AwsVpc } from './types/aws-vpc.js';
+
+import type { AwsVpc } from './types/aws-vpc.js';
 
 export interface GetVpcInput {
   vpcId: string;

--- a/src/aws/ec2/parse-ec2-response.ts
+++ b/src/aws/ec2/parse-ec2-response.ts
@@ -1,18 +1,18 @@
-import {
+import { InstanceStateName } from '@aws-sdk/client-ec2';
+import { z } from 'zod';
+
+import { AwsTagParser, transformTags } from '../tags/parse-tags-response.js';
+
+import type {
   Instance,
-  InstanceStateName,
   RouteTable,
   SecurityGroup,
   Subnet,
   Vpc,
 } from '@aws-sdk/client-ec2';
-import { z } from 'zod';
-
-import { AwsTagParser, transformTags } from '../tags/parse-tags-response.js';
-
-import { AwsEc2Instance } from './types/aws-ec2-instance.js';
-import { AwsSecurityGroup } from './types/aws-security-group.js';
-import { AwsVpc, AwsSubnet, AwsRouteTable } from './types/aws-vpc.js';
+import type { AwsEc2Instance } from './types/aws-ec2-instance.js';
+import type { AwsSecurityGroup } from './types/aws-security-group.js';
+import type { AwsVpc, AwsSubnet, AwsRouteTable } from './types/aws-vpc.js';
 
 export const parseEc2InstanceResponse: (response: Instance) => AwsEc2Instance =
   z

--- a/src/aws/ec2/types/aws-ec2-instance.ts
+++ b/src/aws/ec2/types/aws-ec2-instance.ts
@@ -1,8 +1,6 @@
-import { InstanceStateName } from '@aws-sdk/client-ec2';
-
-import { AwsTags } from '../../tags/types.js';
-
-import { AwsSecurityGroupIdentifier } from './aws-security-group.js';
+import type { InstanceStateName } from '@aws-sdk/client-ec2';
+import type { AwsTags } from '../../tags/types.js';
+import type { AwsSecurityGroupIdentifier } from './aws-security-group.js';
 
 export interface AwsEc2Instance {
   id: string;

--- a/src/aws/ec2/types/aws-vpc.ts
+++ b/src/aws/ec2/types/aws-vpc.ts
@@ -1,4 +1,4 @@
-import { AwsTags } from '../../tags/types.js';
+import type { AwsTags } from '../../tags/types.js';
 
 export interface AwsVpc {
   id: string;

--- a/src/aws/ec2/upsert-tags.ts
+++ b/src/aws/ec2/upsert-tags.ts
@@ -1,8 +1,8 @@
 import { CreateTagsCommand } from '@aws-sdk/client-ec2';
 
-import { AwsTag } from '../tags/types.js';
-
 import { ec2Client } from './ec2-client.js';
+
+import type { AwsTag } from '../tags/types.js';
 
 export interface UpsertTagsInput {
   resourceIds: string[];

--- a/src/aws/iam/create-iam-role.ts
+++ b/src/aws/iam/create-iam-role.ts
@@ -7,7 +7,8 @@ import { createIamInlinePolicy } from './create-iam-inline-policy.js';
 import { attachIamPolicy } from './attach-iam-policy.js';
 import { iamClient } from './iam-client.js';
 import { parseRoleResponse } from './parse-iam-response.js';
-import { AwsRole } from './types.js';
+
+import type { AwsRole } from './types.js';
 
 export interface InlinePolicyInput {
   name: string;

--- a/src/aws/iam/create-instance-profile.ts
+++ b/src/aws/iam/create-instance-profile.ts
@@ -9,7 +9,8 @@ import { handleWaiterError } from '../common/waiter-error.js';
 
 import { iamClient } from './iam-client.js';
 import { parseIamInstanceProfileResponse } from './parse-iam-response.js';
-import { AwsIamInstanceProfile } from './types.js';
+
+import type { AwsIamInstanceProfile } from './types.js';
 
 export interface CreateInstanceProfileInput {
   name: string;

--- a/src/aws/iam/get-iam-role.ts
+++ b/src/aws/iam/get-iam-role.ts
@@ -9,7 +9,8 @@ import {
   parseRoleAttachedPolicyResponse,
   parseRoleResponse,
 } from './parse-iam-response.js';
-import { AwsRole, AwsRoleAttachedPolicy } from './types.js';
+
+import type { AwsRole, AwsRoleAttachedPolicy } from './types.js';
 
 export interface GetIamRoleInput {
   path: string;

--- a/src/aws/iam/get-instance-profiles.ts
+++ b/src/aws/iam/get-instance-profiles.ts
@@ -5,7 +5,8 @@ import {
 
 import { iamClient } from './iam-client.js';
 import { parseIamInstanceProfileResponse } from './parse-iam-response.js';
-import { AwsIamInstanceProfile } from './types.js';
+
+import type { AwsIamInstanceProfile } from './types.js';
 
 export interface GetInstanceProfilesInput {
   path: string;

--- a/src/aws/iam/parse-iam-response.ts
+++ b/src/aws/iam/parse-iam-response.ts
@@ -1,7 +1,11 @@
-import { AttachedPolicy, InstanceProfile, Role } from '@aws-sdk/client-iam';
 import { z } from 'zod';
 
-import {
+import type {
+  AttachedPolicy,
+  InstanceProfile,
+  Role,
+} from '@aws-sdk/client-iam';
+import type {
   AwsIamInstanceProfile,
   AwsRole,
   AwsRoleAttachedPolicy,

--- a/src/aws/rds/get-db-clusters.ts
+++ b/src/aws/rds/get-db-clusters.ts
@@ -4,7 +4,8 @@ import { AwsNotFoundError } from '../common/aws-errors.js';
 
 import { parseDbClusterResponse } from './parse-rds-response.js';
 import { rdsClient } from './rds-client.js';
-import { AwsDbCluster } from './rds-types.js';
+
+import type { AwsDbCluster } from './rds-types.js';
 
 export interface GetDbInstanceInput {
   identifier: string;

--- a/src/aws/rds/get-db-instances.ts
+++ b/src/aws/rds/get-db-instances.ts
@@ -4,7 +4,8 @@ import { AwsNotFoundError } from '../common/aws-errors.js';
 
 import { parseDbInstanceResponse } from './parse-rds-response.js';
 import { rdsClient } from './rds-client.js';
-import { AwsDbInstance } from './rds-types.js';
+
+import type { AwsDbInstance } from './rds-types.js';
 
 export interface GetDbInstanceInput {
   identifier: string;

--- a/src/aws/rds/get-db-subnet-group.ts
+++ b/src/aws/rds/get-db-subnet-group.ts
@@ -4,7 +4,8 @@ import { AwsNotFoundError } from '../common/aws-errors.js';
 
 import { parseDbSubnetGroup } from './parse-rds-response.js';
 import { rdsClient } from './rds-client.js';
-import { AwsDbSubnetGroup } from './rds-types.js';
+
+import type { AwsDbSubnetGroup } from './rds-types.js';
 
 export interface GetSubnetGroupInput {
   name: string;

--- a/src/aws/rds/modify-db-cluster.ts
+++ b/src/aws/rds/modify-db-cluster.ts
@@ -2,7 +2,8 @@ import { ModifyDBClusterCommand } from '@aws-sdk/client-rds';
 
 import { parseDbClusterResponse } from './parse-rds-response.js';
 import { rdsClient } from './rds-client.js';
-import { AwsDbCluster } from './rds-types.js';
+
+import type { AwsDbCluster } from './rds-types.js';
 
 export interface ModifyDbClusterInput {
   identifier: string;

--- a/src/aws/rds/modify-db-instance.ts
+++ b/src/aws/rds/modify-db-instance.ts
@@ -2,7 +2,8 @@ import { ModifyDBInstanceCommand } from '@aws-sdk/client-rds';
 
 import { parseDbInstanceResponse } from './parse-rds-response.js';
 import { rdsClient } from './rds-client.js';
-import { AwsDbInstance } from './rds-types.js';
+
+import type { AwsDbInstance } from './rds-types.js';
 
 export interface ModifyDbInstanceInput {
   identifier: string;

--- a/src/aws/rds/parse-rds-response.ts
+++ b/src/aws/rds/parse-rds-response.ts
@@ -1,7 +1,11 @@
-import { DBCluster, DBInstance, DBSubnetGroup } from '@aws-sdk/client-rds';
 import { z } from 'zod';
 
-import { AwsDbCluster, AwsDbSubnetGroup, AwsDbInstance } from './rds-types.js';
+import type { DBCluster, DBInstance, DBSubnetGroup } from '@aws-sdk/client-rds';
+import type {
+  AwsDbCluster,
+  AwsDbSubnetGroup,
+  AwsDbInstance,
+} from './rds-types.js';
 
 export const parseDbInstanceResponse: (response?: DBInstance) => AwsDbInstance =
   z

--- a/src/aws/ssm/get-ssm-parameter.ts
+++ b/src/aws/ssm/get-ssm-parameter.ts
@@ -4,7 +4,9 @@ import { AwsError, AwsNotFoundError } from '../common/aws-errors.js';
 
 import { parseSsmParameter } from './parse-ssm-response.js';
 import { ssmClient } from './ssm-client.js';
-import { AwsSsmParameter, AwsSsmParameterTypes } from './types.js';
+import { AwsSsmParameterTypes } from './types.js';
+
+import type { AwsSsmParameter } from './types.js';
 
 export interface GetSsmParameterInput {
   name: string;

--- a/src/aws/ssm/parse-ssm-response.ts
+++ b/src/aws/ssm/parse-ssm-response.ts
@@ -1,7 +1,7 @@
-import { Parameter, StartSessionResponse } from '@aws-sdk/client-ssm';
 import { z } from 'zod';
 
-import { AwsSsmParameter, AwsSsmParameterType } from './types.js';
+import type { Parameter, StartSessionResponse } from '@aws-sdk/client-ssm';
+import type { AwsSsmParameter, AwsSsmParameterType } from './types.js';
 
 const ParameterTypeParser = z.enum(['String', 'SecureString', 'StringList']);
 

--- a/src/aws/ssm/start-session.ts
+++ b/src/aws/ssm/start-session.ts
@@ -2,7 +2,8 @@ import { StartSessionCommand } from '@aws-sdk/client-ssm';
 
 import { parseStartSsmSessionResponse } from './parse-ssm-response.js';
 import { ssmClient } from './ssm-client.js';
-import { AwsSsmSessionDescriptor } from './types.js';
+
+import type { AwsSsmSessionDescriptor } from './types.js';
 
 export interface StartSsmPortForwardingSession {
   bastionInstanceId: string;

--- a/src/aws/ssm/types.ts
+++ b/src/aws/ssm/types.ts
@@ -1,4 +1,7 @@
-import { StartSessionRequest, StartSessionResponse } from '@aws-sdk/client-ssm';
+import type {
+  StartSessionRequest,
+  StartSessionResponse,
+} from '@aws-sdk/client-ssm';
 
 export const AwsSsmParameterTypes = {
   STRING: 'string',

--- a/src/aws/tags/get-tag-filter.ts
+++ b/src/aws/tags/get-tag-filter.ts
@@ -1,6 +1,5 @@
-import { Filter } from '@aws-sdk/client-ec2';
-
-import { AwsTag } from './types.js';
+import type { Filter } from '@aws-sdk/client-ec2';
+import type { AwsTag } from './types.js';
 
 export function getTagFilter(tag: AwsTag): Filter {
   return {

--- a/src/aws/tags/parse-tags-response.ts
+++ b/src/aws/tags/parse-tags-response.ts
@@ -1,7 +1,7 @@
-import { Tag } from '@aws-sdk/client-ec2';
 import { z } from 'zod';
 
-import { AwsTags } from './types.js';
+import type { Tag } from '@aws-sdk/client-ec2';
+import type { AwsTags } from './types.js';
 
 export const AwsTagParser = z.object({
   Key: z.string(),

--- a/src/bastion/bastion.ts
+++ b/src/bastion/bastion.ts
@@ -1,6 +1,5 @@
-import { InstanceStateName } from '@aws-sdk/client-ec2';
-
-import { AwsEc2Instance } from '../aws/ec2/types/aws-ec2-instance.js';
+import type { InstanceStateName } from '@aws-sdk/client-ec2';
+import type { AwsEc2Instance } from '../aws/ec2/types/aws-ec2-instance.js';
 
 export interface Bastion {
   id: string;

--- a/src/bastion/create-bastion-role.ts
+++ b/src/bastion/create-bastion-role.ts
@@ -1,6 +1,6 @@
 import { createIamInlinePolicy } from '#src/aws/iam/create-iam-inline-policy.js';
 import { createIamRole } from '#src/aws/iam/create-iam-role.js';
-import { AwsRole } from '#src/aws/iam/types.js';
+import type { AwsRole } from '#src/aws/iam/types.js';
 
 import {
   BASTION_INSTANCE_ROLE_NAME_PREFIX,

--- a/src/bastion/create-bastion.ts
+++ b/src/bastion/create-bastion.ts
@@ -2,9 +2,6 @@ import { InstanceStateName } from '@aws-sdk/client-ec2';
 
 import { createEc2Instance } from '../aws/ec2/create-ec2-instance.js';
 import { createSecurityGroup } from '../aws/ec2/create-security-group.js';
-import { AwsEc2Instance } from '../aws/ec2/types/aws-ec2-instance.js';
-import { AwsSecurityGroup } from '../aws/ec2/types/aws-security-group.js';
-import { AwsRole } from '../aws/iam/types.js';
 import { getStringSsmParameter } from '../aws/ssm/get-ssm-parameter.js';
 import { generateShortId } from '../common/short-id.js';
 
@@ -18,13 +15,17 @@ import {
   BastionSecurityGroupCreationError,
 } from './bastion-errors.js';
 import {
-  Bastion,
   BASTION_INSTANCE_ID_TAG_NAME,
   BASTION_INSTANCE_IN_USE_TAG_NAME,
   BASTION_INSTANCE_NAME_PREFIX,
   BASTION_INSTANCE_PROFILE_PATH,
   BASTION_INSTANCE_SECURITY_GROUP_NAME_PREFIX,
 } from './bastion.js';
+
+import type { Bastion } from './bastion.js';
+import type { AwsRole } from '../aws/iam/types.js';
+import type { AwsSecurityGroup } from '../aws/ec2/types/aws-security-group.js';
+import type { AwsEc2Instance } from '../aws/ec2/types/aws-ec2-instance.js';
 
 interface CreateBastionHooks {
   onRetrievingImageId?: () => void;

--- a/src/bastion/ensure-bastion-running.ts
+++ b/src/bastion/ensure-bastion-running.ts
@@ -1,6 +1,5 @@
 import { AwsNoRootVolumeAttachedError } from '../aws/ec2/ec2-errors.js';
 import { startEc2Instance } from '../aws/ec2/start-ec2-instance.js';
-import { AwsEc2Instance } from '../aws/ec2/types/aws-ec2-instance.js';
 import {
   waitEc2InstanceIsRunning,
   waitEc2InstanceIsStopped,
@@ -8,7 +7,9 @@ import {
 import { UnexpectedStateError } from '../common/runtime-errors.js';
 
 import { StartingInstanceError } from './bastion-errors.js';
-import { Bastion } from './bastion.js';
+
+import type { AwsEc2Instance } from '../aws/ec2/types/aws-ec2-instance.js';
+import type { Bastion } from './bastion.js';
 
 interface EnsureBastionRunningHooks {
   onWaitingInstanceToStart?: () => void;

--- a/src/bastion/get-bastion.ts
+++ b/src/bastion/get-bastion.ts
@@ -1,7 +1,7 @@
 import { InstanceStateName } from '@aws-sdk/client-ec2';
 
-import { AwsEc2Instance } from '#src/aws/ec2/types/aws-ec2-instance.js';
-import { AwsSecurityGroupIdentifier } from '#src/aws/ec2/types/aws-security-group.js';
+import type { AwsEc2Instance } from '#src/aws/ec2/types/aws-ec2-instance.js';
+import type { AwsSecurityGroupIdentifier } from '#src/aws/ec2/types/aws-security-group.js';
 
 import { getEc2Instances } from '../aws/ec2/get-ec2-instances.js';
 import { ManagedResourceTypes } from '../common/resource-type.js';
@@ -11,12 +11,12 @@ import {
 } from '../common/runtime-errors.js';
 
 import {
-  Bastion,
-  BastionState,
   BASTION_INSTANCE_ID_TAG_NAME,
   BASTION_INSTANCE_SECURITY_GROUP_NAME_PREFIX,
   BASTION_INSTANCE_UPDATING_TAG_NAME,
 } from './bastion.js';
+
+import type { Bastion, BastionState } from './bastion.js';
 
 export interface GetBastionInput {
   bastionId?: string;

--- a/src/cleanup/bastion-instance-cleaner.ts
+++ b/src/cleanup/bastion-instance-cleaner.ts
@@ -1,6 +1,6 @@
 import { terminateEc2Instances } from '../aws/ec2/terminate-ec2-instances.js';
 
-import { ResourceCleaner } from './resource-cleaner.js';
+import type { ResourceCleaner } from './resource-cleaner.js';
 
 export const bastionInstanceCleaner: ResourceCleaner = async instanceId => {
   await terminateEc2Instances({ instanceIds: [instanceId] });

--- a/src/cleanup/bastion-instance-profile-cleaner.ts
+++ b/src/cleanup/bastion-instance-profile-cleaner.ts
@@ -1,6 +1,6 @@
 import { deleteInstanceProfile } from '../aws/iam/delete-instance-profile.js';
 
-import { ResourceCleaner } from './resource-cleaner.js';
+import type { ResourceCleaner } from './resource-cleaner.js';
 
 export const bastionInstanceProfileCleaner: ResourceCleaner =
   async profileName => {

--- a/src/cleanup/bastion-role-cleaner.ts
+++ b/src/cleanup/bastion-role-cleaner.ts
@@ -1,6 +1,6 @@
 import { deleteIamRole } from '../aws/iam/delete-iam-role.js';
 
-import { ResourceCleaner } from './resource-cleaner.js';
+import type { ResourceCleaner } from './resource-cleaner.js';
 
 export const bastionRoleCleaner: ResourceCleaner = async roleName => {
   await deleteIamRole({ roleName });

--- a/src/cleanup/cleanup-managed-resources.ts
+++ b/src/cleanup/cleanup-managed-resources.ts
@@ -1,20 +1,20 @@
-import {
-  ManagedResourceType,
-  ManagedResourceTypes,
-} from '../common/resource-type.js';
+import { ManagedResourceTypes } from '../common/resource-type.js';
 
 import { bastionInstanceCleaner } from './bastion-instance-cleaner.js';
 import { bastionInstanceProfileCleaner } from './bastion-instance-profile-cleaner.js';
 import { bastionRoleCleaner } from './bastion-role-cleaner.js';
-import {
-  ResourcesCleanupPreparer,
-  ResourceCleaner,
-} from './resource-cleaner.js';
-import { CLEANUP_ORDER, ManagedResources } from './managed-resources.js';
+import { CLEANUP_ORDER } from './managed-resources.js';
 import {
   accessSecurityGroupReferencesCleaner,
   securityGroupCleaner,
 } from './security-group-cleaner.js';
+
+import type {
+  ResourcesCleanupPreparer,
+  ResourceCleaner,
+} from './resource-cleaner.js';
+import type { ManagedResources } from './managed-resources.js';
+import type { ManagedResourceType } from '../common/resource-type.js';
 
 interface CleanupManagedResourcesHooks {
   onPreparingToCleanup?: (resourceGroup: ManagedResourceType) => void;

--- a/src/cleanup/get-resources-to-cleanup.ts
+++ b/src/cleanup/get-resources-to-cleanup.ts
@@ -10,13 +10,13 @@ import {
   BASTION_INSTANCE_ROLE_PATH,
   BASTION_INSTANCE_SECURITY_GROUP_NAME_PREFIX,
 } from '../bastion/bastion.js';
-import {
-  ManagedResourceType,
-  ManagedResourceTypes,
-} from '../common/resource-type.js';
+import { ManagedResourceTypes } from '../common/resource-type.js';
 import { TARGET_ACCESS_SECURITY_GROUP_NAME_PREFIX } from '../target/target-input.js';
 
-import { CLEANUP_ORDER, ManagedResources } from './managed-resources.js';
+import { CLEANUP_ORDER } from './managed-resources.js';
+
+import type { ManagedResources } from './managed-resources.js';
+import type { ManagedResourceType } from '../common/resource-type.js';
 
 interface GetResourcesToCleanupHooks {
   onRetrievingResources?: (resourceGroup: ManagedResourceType) => void;

--- a/src/cleanup/managed-resources.ts
+++ b/src/cleanup/managed-resources.ts
@@ -1,7 +1,6 @@
-import {
-  ManagedResourceType,
-  ManagedResourceTypes,
-} from '../common/resource-type.js';
+import { ManagedResourceTypes } from '../common/resource-type.js';
+
+import type { ManagedResourceType } from '../common/resource-type.js';
 
 export type ManagedResources = {
   [key in ManagedResourceType]: string[];

--- a/src/cleanup/security-group-cleaner.ts
+++ b/src/cleanup/security-group-cleaner.ts
@@ -6,7 +6,7 @@ import { modifyDBCluster } from '../aws/rds/modify-db-cluster.js';
 import { modifyDbInstance } from '../aws/rds/modify-db-instance.js';
 import { retry } from '../common/retry.js';
 
-import {
+import type {
   ResourcesCleanupPreparer,
   ResourceCleaner,
 } from './resource-cleaner.js';

--- a/src/cli/commands/cleanup/assert-resources-exist.ts
+++ b/src/cli/commands/cleanup/assert-resources-exist.ts
@@ -1,4 +1,4 @@
-import { ManagedResources } from '#src/cleanup/managed-resources.js';
+import type { ManagedResources } from '#src/cleanup/managed-resources.js';
 import { EarlyExitError } from '#src/cli/error/early-exit-error.js';
 
 export interface AssertResourcesExistInput {

--- a/src/cli/commands/cleanup/cleanup-resources.ts
+++ b/src/cli/commands/cleanup/cleanup-resources.ts
@@ -1,13 +1,11 @@
 import { AwsDependencyViolationError } from '#src/aws/common/aws-errors.js';
 import { AwsInvalidRdsStateError } from '#src/aws/rds/rds-errors.js';
 import { cleanupManagedResources } from '#src/cleanup/cleanup-managed-resources.js';
-import { ManagedResources } from '#src/cleanup/managed-resources.js';
+import type { ManagedResources } from '#src/cleanup/managed-resources.js';
 import { cli } from '#src/common/cli.js';
 import { fmt } from '#src/common/fmt.js';
-import {
-  ManagedResourceType,
-  ManagedResourceTypes,
-} from '#src/common/resource-type.js';
+import type { ManagedResourceType } from '#src/common/resource-type.js';
+import { ManagedResourceTypes } from '#src/common/resource-type.js';
 
 import { detailProvider } from '../../error/get-error-detail.js';
 import { OperationError } from '../../error/operation-error.js';

--- a/src/cli/commands/cleanup/cleanup-resources.ts
+++ b/src/cli/commands/cleanup/cleanup-resources.ts
@@ -70,7 +70,7 @@ function toPreparationError(
   group: ManagedResourceType,
   error: unknown
 ): OperationError {
-  return OperationError.from({
+  return OperationError.fromError({
     operationName: `Preparing to ${fmt.lower(RESOURCE_NAMES[group])} deletion`,
     error,
     detailProviders: [
@@ -88,7 +88,7 @@ function toCleanupError(
   id: string,
   error: unknown
 ): OperationError {
-  return OperationError.from({
+  return OperationError.fromError({
     operationName: `Deleting ${fmt.lower(RESOURCE_NAMES[group])} "${id}"`,
     error,
     detailProviders: [

--- a/src/cli/commands/cleanup/confirm-cleanup.ts
+++ b/src/cli/commands/cleanup/confirm-cleanup.ts
@@ -1,13 +1,9 @@
-import {
-  CLEANUP_ORDER,
-  ManagedResources,
-} from '#src/cleanup/managed-resources.js';
+import type { ManagedResources } from '#src/cleanup/managed-resources.js';
+import { CLEANUP_ORDER } from '#src/cleanup/managed-resources.js';
 import { cli } from '#src/common/cli.js';
 import { fmt } from '#src/common/fmt.js';
-import {
-  ManagedResourceType,
-  ManagedResourceTypes,
-} from '#src/common/resource-type.js';
+import type { ManagedResourceType } from '#src/common/resource-type.js';
+import { ManagedResourceTypes } from '#src/common/resource-type.js';
 
 import { EarlyExitError } from '../../error/early-exit-error.js';
 

--- a/src/cli/commands/cleanup/get-resources-to-cleanup.ts
+++ b/src/cli/commands/cleanup/get-resources-to-cleanup.ts
@@ -1,11 +1,9 @@
 import * as cleanupOps from '#src/cleanup/get-resources-to-cleanup.js';
-import { ManagedResources } from '#src/cleanup/managed-resources.js';
+import type { ManagedResources } from '#src/cleanup/managed-resources.js';
 import { cli } from '#src/common/cli.js';
 import { fmt } from '#src/common/fmt.js';
-import {
-  ManagedResourceType,
-  ManagedResourceTypes,
-} from '#src/common/resource-type.js';
+import type { ManagedResourceType } from '#src/common/resource-type.js';
+import { ManagedResourceTypes } from '#src/common/resource-type.js';
 
 import { getErrorDetail } from '../../error/get-error-detail.js';
 

--- a/src/cli/commands/common/get-or-throw.ts
+++ b/src/cli/commands/common/get-or-throw.ts
@@ -1,4 +1,4 @@
-import { ResourceType } from '#src/common/resource-type.js';
+import type { ResourceType } from '#src/common/resource-type.js';
 import { ResourceNotFoundError } from '#src/common/runtime-errors.js';
 
 export async function orThrow<T>(

--- a/src/cli/commands/common/handle-operation.ts
+++ b/src/cli/commands/common/handle-operation.ts
@@ -1,8 +1,9 @@
 import { cli } from '#src/common/cli.js';
 import { fmt } from '#src/common/fmt.js';
 
-import { DetailProvider } from '../../error/get-error-detail.js';
 import { OperationError } from '../../error/operation-error.js';
+
+import type { DetailProvider } from '../../error/get-error-detail.js';
 
 export async function handleOperation<T>(
   operationName: string,

--- a/src/cli/commands/common/handle-operation.ts
+++ b/src/cli/commands/common/handle-operation.ts
@@ -13,7 +13,7 @@ export async function handleOperation<T>(
     cli.progressStart(fmt.capitalize(operationName));
     return await handler();
   } catch (error) {
-    throw OperationError.from({
+    throw OperationError.fromError({
       operationName,
       error,
       detailProviders,

--- a/src/cli/commands/common/hydrate-aws-target.ts
+++ b/src/cli/commands/common/hydrate-aws-target.ts
@@ -3,7 +3,8 @@ import { getDbInstance } from '#src/aws/rds/get-db-instances.js';
 import { TargetTypes } from '#src/common/resource-type.js';
 
 import { orThrow } from './get-or-throw.js';
-import { AwsTargetInput } from './prompt-for-aws-target.js';
+
+import type { AwsTargetInput } from './prompt-for-aws-target.js';
 
 export type DehydratedAwsTargetInput =
   | { rdsInstanceId: string }

--- a/src/cli/commands/common/prompt-for-aws-target.ts
+++ b/src/cli/commands/common/prompt-for-aws-target.ts
@@ -1,16 +1,19 @@
-import inquirer, { DistinctChoice } from 'inquirer';
+import inquirer from 'inquirer';
 
 import { getDbClusters } from '#src/aws/rds/get-db-clusters.js';
 import { getDbInstances } from '#src/aws/rds/get-db-instances.js';
-import { AwsDbCluster, AwsDbInstance } from '#src/aws/rds/rds-types.js';
-import { Cli, cli } from '#src/common/cli.js';
+import type { AwsDbCluster, AwsDbInstance } from '#src/aws/rds/rds-types.js';
+import type { Cli } from '#src/common/cli.js';
+import { cli } from '#src/common/cli.js';
 import { fmt } from '#src/common/fmt.js';
-import {
+import type {
   DbClusterTargetInput,
   DbInstanceTargetInput,
 } from '#src/target/target-input.js';
 
 import { getErrorDetail } from '../../error/get-error-detail.js';
+
+import type { DistinctChoice } from 'inquirer';
 
 export type AwsTargetInput = DbInstanceTargetInput | DbClusterTargetInput;
 

--- a/src/cli/commands/connect/assert-target-is-initialized.ts
+++ b/src/cli/commands/connect/assert-target-is-initialized.ts
@@ -1,5 +1,5 @@
 import { fmt } from '#src/common/fmt.js';
-import { ConnectTarget } from '#src/target/connect-target.js';
+import type { ConnectTarget } from '#src/target/connect-target.js';
 
 import { EarlyExitError } from '../../error/early-exit-error.js';
 import { handleOperation } from '../common/handle-operation.js';

--- a/src/cli/commands/connect/connect.ts
+++ b/src/cli/commands/connect/connect.ts
@@ -1,12 +1,11 @@
 import { assertTargetIsInitialized } from './assert-target-is-initialized.js';
 import { ensureBastionRunning } from './ensure-bastion-running.js';
 import { getBastion } from './get-bastion.js';
-import {
-  DehydratedConnectTargetInput,
-  selectConnectTarget,
-} from './select-connect-target.js';
+import { selectConnectTarget } from './select-connect-target.js';
 import { selectPort } from './select-port.js';
 import { startPortForwarding } from './start-port-forwarding.js';
+
+import type { DehydratedConnectTargetInput } from './select-connect-target.js';
 
 export interface ConnectCommandInput {
   target?: DehydratedConnectTargetInput;

--- a/src/cli/commands/connect/ensure-bastion-running.ts
+++ b/src/cli/commands/connect/ensure-bastion-running.ts
@@ -40,7 +40,7 @@ export async function ensureBastionRunning({
   } catch (error) {
     cli.progressFailure();
 
-    throw OperationError.from({
+    throw OperationError.fromError({
       operationName: 'Starting bastion instance',
       error,
       detailProviders: [

--- a/src/cli/commands/connect/ensure-bastion-running.ts
+++ b/src/cli/commands/connect/ensure-bastion-running.ts
@@ -1,5 +1,5 @@
 import * as bastionOps from '#src/bastion/ensure-bastion-running.js';
-import { Bastion } from '#src/bastion/bastion.js';
+import type { Bastion } from '#src/bastion/bastion.js';
 import { cli } from '#src/common/cli.js';
 import { AwsNoRootVolumeAttachedError } from '#src/aws/ec2/ec2-errors.js';
 import { StartingInstanceError } from '#src/bastion/bastion-errors.js';

--- a/src/cli/commands/connect/get-bastion.ts
+++ b/src/cli/commands/connect/get-bastion.ts
@@ -28,7 +28,7 @@ export async function getBastion({
   );
 
   if (!bastion) {
-    throw OperationError.from({
+    throw OperationError.fromError({
       operationName: 'Retrieving bastion',
       error: new UnexpectedStateError(
         new ResourceNotFoundError(

--- a/src/cli/commands/connect/get-bastion.ts
+++ b/src/cli/commands/connect/get-bastion.ts
@@ -1,11 +1,11 @@
-import { Bastion } from '#src/bastion/bastion.js';
+import type { Bastion } from '#src/bastion/bastion.js';
 import * as bastionOps from '#src/bastion/get-bastion.js';
 import { ManagedResourceTypes } from '#src/common/resource-type.js';
 import {
   ResourceNotFoundError,
   UnexpectedStateError,
 } from '#src/common/runtime-errors.js';
-import { ConnectTarget } from '#src/target/connect-target.js';
+import type { ConnectTarget } from '#src/target/connect-target.js';
 
 import { OperationError } from '../../error/operation-error.js';
 import { handleOperation } from '../common/handle-operation.js';

--- a/src/cli/commands/connect/select-connect-target.ts
+++ b/src/cli/commands/connect/select-connect-target.ts
@@ -5,6 +5,7 @@ import {
   CustomConnectTargetInput,
 } from '#src/target/target-input.js';
 import { cli } from '#src/common/cli.js';
+import { AwsClientConfiguration } from '#src/aws/common/aws-client.js';
 
 import { promptForCustomTargetVpc } from '../common/prompt-for-custom-target-vpc.js';
 import { promptForAwsTarget } from '../common/prompt-for-aws-target.js';
@@ -20,13 +21,16 @@ const IP_REGEX = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$/;
 const DOMAIN_NAME_REGEX =
   /^(?:[\da-z](?:[\da-z-]{0,61}[\da-z])?\.)+[\da-z][\da-z-]{0,61}[\da-z]$/;
 
-export type DehydratedConnectTargetInput =
+export type DehydratedConnectTargetInput = (
   | DehydratedAwsTargetInput
   | {
       customTargetVpcId: string;
       customTargetHost: string;
       customTargetPort: number;
-    };
+    }
+) & {
+  awsClientConfig?: AwsClientConfiguration;
+};
 
 export async function selectConnectTarget(
   dehydratedInput?: DehydratedConnectTargetInput
@@ -44,17 +48,21 @@ export async function selectConnectTarget(
 async function hydrateInput(
   dehydratedInput: DehydratedConnectTargetInput
 ): Promise<ConnectTargetInput> {
-  if ('customTargetVpcId' in dehydratedInput) {
-    return {
-      custom: {
-        vpcId: dehydratedInput.customTargetVpcId,
-        host: dehydratedInput.customTargetHost,
-        port: dehydratedInput.customTargetPort,
-      },
-    };
-  }
+  const targetInput =
+    'customTargetVpcId' in dehydratedInput
+      ? {
+          custom: {
+            vpcId: dehydratedInput.customTargetVpcId,
+            host: dehydratedInput.customTargetHost,
+            port: dehydratedInput.customTargetPort,
+          },
+        }
+      : await hydrateAwsTarget(dehydratedInput);
 
-  return await hydrateAwsTarget(dehydratedInput);
+  return {
+    ...targetInput,
+    awsClientConfig: dehydratedInput.awsClientConfig,
+  };
 }
 
 async function promptForTarget(): Promise<ConnectTargetInput> {

--- a/src/cli/commands/connect/select-connect-target.ts
+++ b/src/cli/commands/connect/select-connect-target.ts
@@ -1,21 +1,20 @@
-import { ConnectTarget } from '#src/target/connect-target.js';
+import type { ConnectTarget } from '#src/target/connect-target.js';
 import { createConnectTarget } from '#src/target/create-connect-target.js';
-import {
+import type {
   ConnectTargetInput,
   CustomConnectTargetInput,
 } from '#src/target/target-input.js';
 import { cli } from '#src/common/cli.js';
-import { AwsClientConfiguration } from '#src/aws/common/aws-client.js';
+import type { AwsClientConfiguration } from '#src/aws/common/aws-client.js';
 
 import { promptForCustomTargetVpc } from '../common/prompt-for-custom-target-vpc.js';
 import { promptForAwsTarget } from '../common/prompt-for-aws-target.js';
-import {
-  DehydratedAwsTargetInput,
-  hydrateAwsTarget,
-} from '../common/hydrate-aws-target.js';
+import { hydrateAwsTarget } from '../common/hydrate-aws-target.js';
 import { handleOperation } from '../common/handle-operation.js';
 
 import { selectPort } from './select-port.js';
+
+import type { DehydratedAwsTargetInput } from '../common/hydrate-aws-target.js';
 
 const IP_REGEX = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$/;
 const DOMAIN_NAME_REGEX =

--- a/src/cli/commands/connect/start-port-forwarding.ts
+++ b/src/cli/commands/connect/start-port-forwarding.ts
@@ -1,6 +1,6 @@
 import { AwsSsmInstanceNotConnectedError } from '#src/aws/ssm/ssm-errors.js';
 import { EarlyExitError } from '#src/cli/error/early-exit-error.js';
-import { ChildProcessExitDescription } from '#src/common/child-process.js';
+import type { ChildProcessExitDescription } from '#src/common/child-process.js';
 import { cli } from '#src/common/cli.js';
 import { fmt } from '#src/common/fmt.js';
 import {
@@ -9,14 +9,15 @@ import {
   SessionManagerPluginPortInUseError,
 } from '#src/session/session-errors.js';
 import { startPortForwardingSession } from '#src/session/start-port-forwarding-session.js';
-import { ConnectTarget } from '#src/target/connect-target.js';
+import type { ConnectTarget } from '#src/target/connect-target.js';
 
 import {
-  DetailProvider,
   detailProvider,
   getErrorDetail,
 } from '../../error/get-error-detail.js';
 import { OperationError } from '../../error/operation-error.js';
+
+import type { DetailProvider } from '../../error/get-error-detail.js';
 
 export interface StartPortForwardingInput {
   target: ConnectTarget;

--- a/src/cli/commands/connect/start-port-forwarding.ts
+++ b/src/cli/commands/connect/start-port-forwarding.ts
@@ -65,7 +65,7 @@ function handleSessionEnded(
 }
 
 function handleSessionError(error: Error): never {
-  throw OperationError.from({
+  throw OperationError.fromError({
     operationName: 'Running port forwarding session',
     error,
     detailProviders: [getSessionManagerExitDetailProvider()],
@@ -81,7 +81,7 @@ function handleMarkingError(error: unknown): void {
 }
 
 function handleSessionStartError(error: unknown, localPort: number): never {
-  throw OperationError.from({
+  throw OperationError.fromError({
     operationName: 'Starting port forwarding session',
     error,
     detailProviders: [

--- a/src/cli/commands/init/allow-target-access.ts
+++ b/src/cli/commands/init/allow-target-access.ts
@@ -57,7 +57,7 @@ export async function allowTargetAccess({
   } catch (error) {
     subCli.progressFailure();
 
-    throw OperationError.from({
+    throw OperationError.fromError({
       operationName: 'Configuring target access',
       error,
       dirtyOperation: true,

--- a/src/cli/commands/init/allow-target-access.ts
+++ b/src/cli/commands/init/allow-target-access.ts
@@ -1,8 +1,8 @@
 import { AwsTooManySecurityGroupsAttachedError } from '#src/aws/rds/rds-errors.js';
-import { Bastion } from '#src/bastion/bastion.js';
+import type { Bastion } from '#src/bastion/bastion.js';
 import { cli } from '#src/common/cli.js';
 import { fmt } from '#src/common/fmt.js';
-import { InitTarget } from '#src/target/init-target.js';
+import type { InitTarget } from '#src/target/init-target.js';
 import {
   AccessSecurityGroupCreationError,
   AccessSecurityGroupAttachmentError,

--- a/src/cli/commands/init/assert-target-is-not-initiated.ts
+++ b/src/cli/commands/init/assert-target-is-not-initiated.ts
@@ -1,5 +1,5 @@
 import { fmt } from '#src/common/fmt.js';
-import { InitTarget } from '#src/target/init-target.js';
+import type { InitTarget } from '#src/target/init-target.js';
 
 import { EarlyExitError } from '../../error/early-exit-error.js';
 import { handleOperation } from '../common/handle-operation.js';

--- a/src/cli/commands/init/create-bastion.ts
+++ b/src/cli/commands/init/create-bastion.ts
@@ -6,7 +6,7 @@ import {
   BastionInstanceCreationError,
   BastionInlinePoliciesCreationError,
 } from '#src/bastion/bastion-errors.js';
-import { Bastion } from '#src/bastion/bastion.js';
+import type { Bastion } from '#src/bastion/bastion.js';
 import * as bastionOps from '#src/bastion/create-bastion.js';
 import { cli } from '#src/common/cli.js';
 import { fmt } from '#src/common/fmt.js';

--- a/src/cli/commands/init/create-bastion.ts
+++ b/src/cli/commands/init/create-bastion.ts
@@ -70,7 +70,7 @@ export async function createBastion({
   } catch (error) {
     subCli.progressFailure();
 
-    throw OperationError.from({
+    throw OperationError.fromError({
       operationName: 'Setting up bastion',
       error,
       dirtyOperation: true,

--- a/src/cli/commands/init/get-bastion.ts
+++ b/src/cli/commands/init/get-bastion.ts
@@ -1,4 +1,4 @@
-import { Bastion } from '#src/bastion/bastion.js';
+import type { Bastion } from '#src/bastion/bastion.js';
 import * as bastionOps from '#src/bastion/get-bastion.js';
 import { cli } from '#src/common/cli.js';
 

--- a/src/cli/commands/init/get-target-vpc.ts
+++ b/src/cli/commands/init/get-target-vpc.ts
@@ -1,4 +1,4 @@
-import { InitTarget } from '#src/target/init-target.js';
+import type { InitTarget } from '#src/target/init-target.js';
 
 import { handleOperation } from '../common/handle-operation.js';
 

--- a/src/cli/commands/init/init.ts
+++ b/src/cli/commands/init/init.ts
@@ -4,10 +4,9 @@ import { createBastion } from './create-bastion.js';
 import { getBastion } from './get-bastion.js';
 import { getTargetVpc } from './get-target-vpc.js';
 import { selectBastionSubnetId } from './select-bastion-subnet.js';
-import {
-  DehydratedInitTargetInput,
-  selectInitTarget,
-} from './select-init-target.js';
+import { selectInitTarget } from './select-init-target.js';
+
+import type { DehydratedInitTargetInput } from './select-init-target.js';
 
 export interface InitCommandInput {
   target?: DehydratedInitTargetInput;

--- a/src/cli/commands/init/select-init-target.ts
+++ b/src/cli/commands/init/select-init-target.ts
@@ -1,5 +1,5 @@
-import { InitTarget } from '#src/target/init-target.js';
-import {
+import type { InitTarget } from '#src/target/init-target.js';
+import type {
   CustomInitTargetInput,
   InitTargetInput,
 } from '#src/target/target-input.js';
@@ -8,10 +8,9 @@ import { createInitTarget } from '#src/target/create-init-target.js';
 import { promptForCustomTargetVpc } from '../common/prompt-for-custom-target-vpc.js';
 import { promptForAwsTarget } from '../common/prompt-for-aws-target.js';
 import { handleOperation } from '../common/handle-operation.js';
-import {
-  DehydratedAwsTargetInput,
-  hydrateAwsTarget,
-} from '../common/hydrate-aws-target.js';
+import { hydrateAwsTarget } from '../common/hydrate-aws-target.js';
+
+import type { DehydratedAwsTargetInput } from '../common/hydrate-aws-target.js';
 
 export type DehydratedInitTargetInput =
   | DehydratedAwsTargetInput

--- a/src/cli/config/config-parser.ts
+++ b/src/cli/config/config-parser.ts
@@ -43,7 +43,7 @@ export type ConnectionTargetConfig = z.infer<
 >;
 
 const ConnectionConfigParser = z.object({
-  target: z.string(),
+  target: z.union([z.string(), ConnectionTargetConfigParser]),
   localPort: z.number(),
 });
 export type ConnectionConfig = z.infer<typeof ConnectionConfigParser>;

--- a/src/cli/config/config-parser.ts
+++ b/src/cli/config/config-parser.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod';
+
+const TargetConfigBaseParser = z.object({
+  awsProfile: z.string().optional(),
+  awsRegion: z.string().optional(),
+});
+export type TargetConfigBase = z.infer<typeof TargetConfigBaseParser>;
+
+const RdsInstanceTargetConfigParser = z
+  .object({
+    rdsInstance: z.string(),
+  })
+  .merge(TargetConfigBaseParser);
+export type RdsInstanceTargetConfig = z.infer<
+  typeof RdsInstanceTargetConfigParser
+>;
+
+const RdsClusterTargetConfigParser = z
+  .object({
+    rdsCluster: z.string(),
+  })
+  .merge(TargetConfigBaseParser);
+export type RdsClusterTargetConfig = z.infer<
+  typeof RdsClusterTargetConfigParser
+>;
+
+const CustomTargetConfigParser = z
+  .object({
+    customTargetVpc: z.string(),
+    customTargetHost: z.string(),
+    customTargetPort: z.number(),
+  })
+  .merge(TargetConfigBaseParser);
+export type CustomTargetConfig = z.infer<typeof CustomTargetConfigParser>;
+
+const ConnectionTargetConfigParser = z.union([
+  RdsInstanceTargetConfigParser,
+  RdsClusterTargetConfigParser,
+  CustomTargetConfigParser,
+]);
+export type ConnectionTargetConfig = z.infer<
+  typeof ConnectionTargetConfigParser
+>;
+
+const ConnectOptionsConfigParser = z.object({
+  target: z.string(),
+  localPort: z.number(),
+});
+export type ConnectOptionsConfig = z.infer<typeof ConnectOptionsConfigParser>;
+
+export const ConfigParser = z.object({
+  connect: z.record(z.string(), ConnectOptionsConfigParser),
+  targets: z.record(z.string(), ConnectionTargetConfigParser),
+});
+export type Config = z.infer<typeof ConfigParser>;
+
+export function isRdsInstanceTargetConfig(
+  target: ConnectionTargetConfig
+): target is RdsInstanceTargetConfig {
+  return 'rdsInstance' in target;
+}
+
+export function isRdsClusterTargetConfig(
+  target: ConnectionTargetConfig
+): target is RdsClusterTargetConfig {
+  return 'rdsCluster' in target;
+}
+
+export function isCustomTargetConfig(
+  target: ConnectionTargetConfig
+): target is CustomTargetConfig {
+  return 'customTargetVpc' in target;
+}

--- a/src/cli/config/config-parser.ts
+++ b/src/cli/config/config-parser.ts
@@ -42,14 +42,14 @@ export type ConnectionTargetConfig = z.infer<
   typeof ConnectionTargetConfigParser
 >;
 
-const ConnectOptionsConfigParser = z.object({
+const ConnectionConfigParser = z.object({
   target: z.string(),
   localPort: z.number(),
 });
-export type ConnectOptionsConfig = z.infer<typeof ConnectOptionsConfigParser>;
+export type ConnectionConfig = z.infer<typeof ConnectionConfigParser>;
 
 export const ConfigParser = z.object({
-  connect: z.record(z.string(), ConnectOptionsConfigParser),
+  connections: z.record(z.string(), ConnectionConfigParser),
   targets: z.record(z.string(), ConnectionTargetConfigParser),
 });
 export type Config = z.infer<typeof ConfigParser>;

--- a/src/cli/config/get-command-input.ts
+++ b/src/cli/config/get-command-input.ts
@@ -10,30 +10,30 @@ import type { Config } from './config-parser.js';
 
 export function getConnectCommandInputFromConfig(
   config: Config | undefined,
-  optionsSet: string
+  connection: string
 ): ConnectCommandInput {
   if (!config) {
     throw OperationError.fromErrorMessage({
-      operationName: 'Resoling options set',
+      operationName: 'Resoling connection from configuration file',
       message: 'No configuration file found',
     });
   }
 
-  const connectOptionsConfig = config.connect[optionsSet];
+  const connectionConfig = config.connections[connection];
 
-  if (!connectOptionsConfig) {
+  if (!connectionConfig) {
     throw OperationError.fromErrorMessage({
-      operationName: 'Resolving options set from configuration file',
-      message: `No options set named "${optionsSet}" found in configuration file`,
+      operationName: 'Resolving connection from configuration file',
+      message: `No connection with name "${connection}" found in configuration file`,
     });
   }
 
-  const connectionTarget = config.targets[connectOptionsConfig.target];
+  const connectionTarget = config.targets[connectionConfig.target];
 
   if (!connectionTarget) {
     throw OperationError.fromErrorMessage({
-      operationName: 'Resoling options set from configuration file',
-      message: `No target named "${connectOptionsConfig.target}" found in configuration file`,
+      operationName: 'Resoling connection from configuration file',
+      message: `No target with name "${connectionConfig.target}" found in configuration file`,
     });
   }
 
@@ -63,6 +63,6 @@ export function getConnectCommandInputFromConfig(
           customTargetPort: connectionTarget.customTargetPort,
           awsClientConfig,
         },
-    localPort: connectOptionsConfig.localPort,
+    localPort: connectionConfig.localPort,
   };
 }

--- a/src/cli/config/get-command-input.ts
+++ b/src/cli/config/get-command-input.ts
@@ -28,12 +28,17 @@ export function getConnectCommandInputFromConfig(
     });
   }
 
-  const connectionTarget = config.targets[connectionConfig.target];
+  const connectionTarget =
+    typeof connectionConfig.target === 'object'
+      ? connectionConfig.target
+      : config.targets[connectionConfig.target];
 
   if (!connectionTarget) {
     throw OperationError.fromErrorMessage({
       operationName: 'Resoling connection from configuration file',
-      message: `No target with name "${connectionConfig.target}" found in configuration file`,
+      message: `No target with name "${
+        connectionConfig.target as string
+      }" found in configuration file`,
     });
   }
 

--- a/src/cli/config/get-command-input.ts
+++ b/src/cli/config/get-command-input.ts
@@ -1,0 +1,68 @@
+import { OperationError } from '../error/operation-error.js';
+
+import {
+  isRdsClusterTargetConfig,
+  isRdsInstanceTargetConfig,
+} from './config-parser.js';
+
+import type { ConnectCommandInput } from '../commands/connect/connect.js';
+import type { Config } from './config-parser.js';
+
+export function getConnectCommandInputFromConfig(
+  config: Config | undefined,
+  optionsSet: string
+): ConnectCommandInput {
+  if (!config) {
+    throw OperationError.fromErrorMessage({
+      operationName: 'Resoling options set',
+      message: 'No configuration file found',
+    });
+  }
+
+  const connectOptionsConfig = config.connect[optionsSet];
+
+  if (!connectOptionsConfig) {
+    throw OperationError.fromErrorMessage({
+      operationName: 'Resolving options set from configuration file',
+      message: `No options set named "${optionsSet}" found in configuration file`,
+    });
+  }
+
+  const connectionTarget = config.targets[connectOptionsConfig.target];
+
+  if (!connectionTarget) {
+    throw OperationError.fromErrorMessage({
+      operationName: 'Resoling options set from configuration file',
+      message: `No target named "${connectOptionsConfig.target}" found in configuration file`,
+    });
+  }
+
+  const awsClientConfig =
+    connectionTarget.awsProfile !== undefined ||
+    connectionTarget.awsRegion !== undefined
+      ? {
+          profile: connectionTarget.awsProfile,
+          region: connectionTarget.awsRegion,
+        }
+      : undefined;
+
+  return {
+    target: isRdsInstanceTargetConfig(connectionTarget)
+      ? {
+          rdsInstanceId: connectionTarget.rdsInstance,
+          awsClientConfig,
+        }
+      : isRdsClusterTargetConfig(connectionTarget)
+      ? {
+          rdsClusterId: connectionTarget.rdsCluster,
+          awsClientConfig,
+        }
+      : {
+          customTargetVpcId: connectionTarget.customTargetVpc,
+          customTargetHost: connectionTarget.customTargetHost,
+          customTargetPort: connectionTarget.customTargetPort,
+          awsClientConfig,
+        },
+    localPort: connectOptionsConfig.localPort,
+  };
+}

--- a/src/cli/config/get-config.ts
+++ b/src/cli/config/get-config.ts
@@ -26,7 +26,7 @@ function parseConfig(config: unknown): Config {
   }
 
   throw OperationError.fromErrorMessage({
-    operationName: 'Parsing config',
+    operationName: 'Parsing configuration file',
     message: fromZodError(result.error).message,
   });
 }

--- a/src/cli/config/get-config.ts
+++ b/src/cli/config/get-config.ts
@@ -26,7 +26,7 @@ function parseConfig(config: unknown): Config {
   }
 
   throw OperationError.fromErrorMessage({
-    operationName: 'Parsing configuration file',
+    operationName: 'Reading configuration file',
     message: fromZodError(result.error).message,
   });
 }

--- a/src/cli/config/get-config.ts
+++ b/src/cli/config/get-config.ts
@@ -8,7 +8,9 @@ import { ConfigParser } from './config-parser.js';
 import type { Config } from './config-parser.js';
 
 export async function getConfig(): Promise<Config | undefined> {
-  const configExplorer = cosmiconfig('basti');
+  const configExplorer = cosmiconfig('basti', {
+    searchPlaces: ['basti.yaml', 'basti.yml', 'basti.json'],
+  });
   const configResult = await configExplorer.search();
 
   if (configResult === null) {

--- a/src/cli/config/get-config.ts
+++ b/src/cli/config/get-config.ts
@@ -1,0 +1,32 @@
+import { cosmiconfig } from 'cosmiconfig';
+import { fromZodError } from 'zod-validation-error';
+
+import { OperationError } from '../error/operation-error.js';
+
+import { ConfigParser } from './config-parser.js';
+
+import type { Config } from './config-parser.js';
+
+export async function getConfig(): Promise<Config | undefined> {
+  const configExplorer = cosmiconfig('basti');
+  const configResult = await configExplorer.search();
+
+  if (configResult === null) {
+    return undefined;
+  }
+
+  return parseConfig(configResult.config);
+}
+
+function parseConfig(config: unknown): Config {
+  const result = ConfigParser.safeParse(config);
+
+  if (result.success) {
+    return result.data;
+  }
+
+  throw OperationError.fromErrorMessage({
+    operationName: 'Parsing config',
+    message: fromZodError(result.error).message,
+  });
+}

--- a/src/cli/error/get-error-detail.ts
+++ b/src/cli/error/get-error-detail.ts
@@ -3,9 +3,9 @@ import {
   AwsDependencyViolationError,
 } from '#src/aws/common/aws-errors.js';
 import { AwsTimeoutError } from '#src/aws/common/waiter-error.js';
+import type { ResourceType } from '#src/common/resource-type.js';
 import {
   ManagedResourceTypes,
-  ResourceType,
   TargetTypes,
 } from '#src/common/resource-type.js';
 import {

--- a/src/cli/error/operation-error.ts
+++ b/src/cli/error/operation-error.ts
@@ -21,7 +21,24 @@ export class OperationError extends RuntimeError {
     );
   }
 
-  public static from({
+  public static fromErrorMessage({
+    operationName,
+    message,
+    dirtyOperation,
+  }: {
+    operationName: string;
+    message: string;
+    dirtyOperation?: boolean;
+  }): OperationError {
+    return new OperationError(
+      operationName,
+      message,
+      undefined,
+      dirtyOperation
+    );
+  }
+
+  public static fromError({
     operationName,
     error,
     detailProviders,

--- a/src/cli/error/operation-error.ts
+++ b/src/cli/error/operation-error.ts
@@ -1,7 +1,9 @@
 import { fmt } from '#src/common/fmt.js';
 import { RuntimeError } from '#src/common/runtime-errors.js';
 
-import { DetailProvider, getErrorDetail } from './get-error-detail.js';
+import { getErrorDetail } from './get-error-detail.js';
+
+import type { DetailProvider } from './get-error-detail.js';
 
 export class OperationError extends RuntimeError {
   operationErrorMessage: string;

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -143,6 +143,12 @@ void yargs(hideBin(process.argv))
           ? getConnectCommandInputFromConfig(config, options.optionsSet)
           : getConnectCommandInputFromOptions(options);
 
+      // TODO: Relying on setting the global configuration before the command is
+      // imported is dangerous as it might be accidentally imported before the
+      // configuration is set. The approach has to be changed to passing the configuration
+      // to the AWS commands directly. This will also become a must with the
+      // introduction of multiple targets connection as each target will have its own
+      // AWS client configuration.
       AwsClient.setGlobalConfiguration(
         commandInput.target?.awsClientConfig ?? getAwsClientOptions(options)
       );

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -75,13 +75,14 @@ void yargs(hideBin(process.argv))
     })
   )
   .command(
-    ['connect [options-set]', 'c'],
+    ['connect [connection]', 'c'],
     'Start port forwarding session with the selected target',
     yargs =>
       yargs
-        .positional('options-set', {
+        .positional('connection', {
           type: 'string',
-          description: 'Name of the options set in the configuration file',
+          description:
+            'Name of the connection in the configuration file. Conflicts with other options',
         })
         .option('rds-instance', {
           type: 'string',
@@ -111,22 +112,22 @@ void yargs(hideBin(process.argv))
         .option(...YARGS_AWS_CLIENT_OPTIONS.AWS_PROFILE)
         .option(...YARGS_AWS_CLIENT_OPTIONS.AWS_REGION)
         .check(
-          conflictingOptions('options-set', 'rds-instance', 'rds-cluster', [
+          conflictingOptions('connection', 'rds-instance', 'rds-cluster', [
             'custom-target-vpc',
             'custom-target-host',
             'custom-target-port',
           ])
         )
-        .check(conflictingOptions('options-set', 'local-port'))
+        .check(conflictingOptions('connection', 'local-port'))
         .check(
           conflictingOptions(
-            'options-set',
+            'connection',
             YARGS_AWS_CLIENT_OPTIONS.AWS_PROFILE[0]
           )
         )
         .check(
           conflictingOptions(
-            'options-set',
+            'connection',
             YARGS_AWS_CLIENT_OPTIONS.AWS_REGION[0]
           )
         )
@@ -144,16 +145,16 @@ void yargs(hideBin(process.argv))
             'Select target and local port automatically',
           ],
           [
-            '$0 connect <options-set>',
-            'Connect to a target defined in the configuration file',
+            '$0 connect <connection>',
+            'Use connection configuration from the configuration file',
           ],
         ]),
     withErrorHandling(async options => {
       const config = await getConfig();
 
       const commandInput =
-        options.optionsSet !== undefined
-          ? getConnectCommandInputFromConfig(config, options.optionsSet)
+        options.connection !== undefined
+          ? getConnectCommandInputFromConfig(config, options.connection)
           : getConnectCommandInputFromOptions(options);
 
       // TODO: Relying on setting the global configuration before the command is

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -160,8 +160,8 @@ void yargs(hideBin(process.argv))
       // imported is dangerous as it might be accidentally imported before the
       // configuration is set. The approach has to be changed to passing the configuration
       // to the AWS commands directly. This will also become a must with the
-      // introduction of multiple targets connection as each target will have its own
-      // AWS client configuration.
+      // introduction of multiple simultaneous connections support as each target
+      // will have its own AWS client configuration.
       AwsClient.setGlobalConfiguration(
         commandInput.target?.awsClientConfig ?? getAwsClientOptions(options)
       );

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -111,11 +111,24 @@ void yargs(hideBin(process.argv))
         .option(...YARGS_AWS_CLIENT_OPTIONS.AWS_PROFILE)
         .option(...YARGS_AWS_CLIENT_OPTIONS.AWS_REGION)
         .check(
-          conflictingOptions('rds-instance', 'rds-cluster', [
+          conflictingOptions('options-set', 'rds-instance', 'rds-cluster', [
             'custom-target-vpc',
             'custom-target-host',
             'custom-target-port',
           ])
+        )
+        .check(conflictingOptions('options-set', 'local-port'))
+        .check(
+          conflictingOptions(
+            'options-set',
+            YARGS_AWS_CLIENT_OPTIONS.AWS_PROFILE[0]
+          )
+        )
+        .check(
+          conflictingOptions(
+            'options-set',
+            YARGS_AWS_CLIENT_OPTIONS.AWS_REGION[0]
+          )
         )
         .check(
           optionGroup(

--- a/src/cli/yargs/aws-client-options.ts
+++ b/src/cli/yargs/aws-client-options.ts
@@ -1,4 +1,4 @@
-import { AwsClientConfiguration } from '#src/aws/common/aws-client.js';
+import type { AwsClientConfiguration } from '#src/aws/common/aws-client.js';
 
 export const YARGS_AWS_CLIENT_OPTIONS = {
   AWS_PROFILE: [

--- a/src/cli/yargs/conflicting-options-check.ts
+++ b/src/cli/yargs/conflicting-options-check.ts
@@ -1,4 +1,6 @@
-import { isOptionInArgs, YargsCheck } from './yargs-check.js';
+import { isOptionInArgs } from './yargs-check.js';
+
+import type { YargsCheck } from './yargs-check.js';
 
 export function conflictingOptions(
   ...options: Array<string | string[]>

--- a/src/cli/yargs/get-command-input.ts
+++ b/src/cli/yargs/get-command-input.ts
@@ -1,0 +1,110 @@
+import type { InitCommandInput } from '../commands/init/init.js';
+import type { ConnectCommandInput } from '../commands/connect/connect.js';
+
+export interface RdsInstanceOptions {
+  rdsInstance: string;
+}
+
+export interface RdsClusterOptions {
+  rdsCluster: string;
+}
+
+export interface CustomTargetVpcOptions {
+  customTargetVpc: string;
+}
+
+export interface CustomTargetOptions {
+  customTargetVpc: string;
+  customTargetHost: string;
+  customTargetPort: number;
+}
+
+export type InitOptions = Partial<RdsInstanceOptions> &
+  Partial<RdsClusterOptions> &
+  Partial<CustomTargetVpcOptions> & {
+    bastionSubnet?: string;
+  };
+
+export type ConnectOptions = Partial<RdsInstanceOptions> &
+  Partial<RdsClusterOptions> &
+  Partial<CustomTargetOptions> & {
+    localPort?: number;
+  };
+
+export interface CleanupOptions {
+  confirm?: boolean;
+}
+
+export function getInitCommandInputFromOptions(
+  options: InitOptions
+): InitCommandInput {
+  return {
+    target: isRdsInstanceOptions(options)
+      ? {
+          rdsInstanceId: options.rdsInstance,
+        }
+      : isRdsClusterOptions(options)
+      ? {
+          rdsClusterId: options.rdsCluster,
+        }
+      : isCustomTargetOptions(options)
+      ? {
+          customTargetVpcId: options.customTargetVpc,
+        }
+      : undefined,
+    bastionSubnet: options.bastionSubnet,
+  };
+}
+
+export function getConnectCommandInputFromOptions(
+  options: ConnectOptions
+): ConnectCommandInput {
+  return {
+    target: isRdsInstanceOptions(options)
+      ? {
+          rdsInstanceId: options.rdsInstance,
+        }
+      : isRdsClusterOptions(options)
+      ? {
+          rdsClusterId: options.rdsCluster,
+        }
+      : isCustomTargetOptions(options)
+      ? {
+          customTargetVpcId: options.customTargetVpc,
+          customTargetHost: options.customTargetHost,
+          customTargetPort: options.customTargetPort,
+        }
+      : undefined,
+    localPort: options.localPort,
+  };
+}
+
+export function getCleanupCommandInputFromOptions(
+  options: CleanupOptions
+): CleanupOptions {
+  return {
+    confirm: options.confirm,
+  };
+}
+
+function isRdsInstanceOptions(
+  options: ConnectOptions | InitOptions
+): options is RdsInstanceOptions {
+  return 'rdsInstance' in options;
+}
+
+function isRdsClusterOptions(
+  options: ConnectOptions | InitOptions
+): options is RdsClusterOptions {
+  return 'rdsCluster' in options;
+}
+
+function isCustomTargetOptions(
+  options: InitOptions
+): options is CustomTargetVpcOptions;
+function isCustomTargetOptions(
+  options: ConnectOptions
+): options is CustomTargetOptions;
+function isCustomTargetOptions(options: ConnectOptions | InitOptions): any {
+  return 'customTargetVpc' in options;
+}

--- a/src/common/cli.ts
+++ b/src/common/cli.ts
@@ -1,8 +1,10 @@
 import inquirer from 'inquirer';
-import ora, { Ora } from 'ora';
+import ora from 'ora';
 
 import { isDebugMode } from './debug.js';
 import { fmt } from './fmt.js';
+
+import type { Ora } from 'ora';
 
 type CliContext =
   | 'info'

--- a/src/common/runtime-errors.ts
+++ b/src/common/runtime-errors.ts
@@ -1,4 +1,4 @@
-import { ResourceType } from './resource-type.js';
+import type { ResourceType } from './resource-type.js';
 
 export function getErrorMessage(error: unknown): string {
   if (error instanceof Error) {

--- a/src/session/session-errors.ts
+++ b/src/session/session-errors.ts
@@ -1,4 +1,4 @@
-import { ChildProcessExitDescription } from '#src/common/child-process.js';
+import type { ChildProcessExitDescription } from '#src/common/child-process.js';
 import { RuntimeError } from '#src/common/runtime-errors.js';
 
 export class SessionManagerPluginNonInstalledError extends RuntimeError {

--- a/src/session/start-port-forwarding-session.ts
+++ b/src/session/start-port-forwarding-session.ts
@@ -1,13 +1,14 @@
-import { ChildProcessExitDescription } from '#src/common/child-process.js';
+import type { ChildProcessExitDescription } from '#src/common/child-process.js';
 
 import { startSsmPortForwardingSession } from '../aws/ssm/start-session.js';
 import { retry } from '../common/retry.js';
-import { ConnectTarget } from '../target/connect-target.js';
 import { AwsSsmInstanceNotConnectedError } from '../aws/ssm/ssm-errors.js';
-import { AwsSsmSessionDescriptor } from '../aws/ssm/types.js';
 
 import { startBastionUsageMarker } from './start-bastion-usage-marker.js';
 import { startSessionManagerPluginProcess } from './start-session-manager-plugin-process.js';
+
+import type { AwsSsmSessionDescriptor } from '../aws/ssm/types.js';
+import type { ConnectTarget } from '../target/connect-target.js';
 
 export interface StartPortForwardingSessionHooks {
   onSessionError?: (error: Error) => void;

--- a/src/session/start-session-manager-plugin-process.ts
+++ b/src/session/start-session-manager-plugin-process.ts
@@ -2,18 +2,19 @@ import fs from 'node:fs';
 import path from 'node:path';
 import url from 'node:url';
 
-import { AwsSsmSessionDescriptor } from '../aws/ssm/types.js';
-import {
-  ChildProcessExitDescription,
-  OutputOptimizedChildProcess,
-  spawnProcess,
-} from '../common/child-process.js';
+import { spawnProcess } from '../common/child-process.js';
 
 import {
   SessionManagerPluginExitError,
   SessionManagerPluginPortInUseError,
   SessionManagerPluginNonInstalledError,
 } from './session-errors.js';
+
+import type { AwsSsmSessionDescriptor } from '../aws/ssm/types.js';
+import type {
+  ChildProcessExitDescription,
+  OutputOptimizedChildProcess,
+} from '../common/child-process.js';
 
 export interface StartSessionManagerPluginHooks {
   onExit?: (exitDescription: ChildProcessExitDescription) => void;

--- a/src/target/connect-target.ts
+++ b/src/target/connect-target.ts
@@ -1,16 +1,15 @@
-import { AwsClientConfiguration } from '#src/aws/common/aws-client.js';
+import type { AwsClientConfiguration } from '#src/aws/common/aws-client.js';
 
 import { getSecurityGroups } from '../aws/ec2/get-security-groups.js';
-import {
-  AwsSecurityGroup,
-  isGroupSecurityGroupSource,
-} from '../aws/ec2/types/aws-security-group.js';
+import { isGroupSecurityGroupSource } from '../aws/ec2/types/aws-security-group.js';
 import { BASTION_INSTANCE_NAME_PREFIX } from '../bastion/bastion.js';
 import { ManagedResourceTypes } from '../common/resource-type.js';
 import { ResourceDamagedError } from '../common/runtime-errors.js';
 
 import { TargetNotInitializedError } from './target-errors.js';
 import { TARGET_ACCESS_SECURITY_GROUP_NAME_PREFIX } from './target-input.js';
+
+import type { AwsSecurityGroup } from '../aws/ec2/types/aws-security-group.js';
 
 export interface ConnectTarget {
   // Per-target AWS client config can only be specified via config file.

--- a/src/target/connect-target.ts
+++ b/src/target/connect-target.ts
@@ -13,7 +13,8 @@ import type { AwsSecurityGroup } from '../aws/ec2/types/aws-security-group.js';
 
 export interface ConnectTarget {
   // Per-target AWS client config can only be specified via config file.
-  // In interactive mode as well as with CLI arguments, global client config is used.
+  // Until multiple simultaneous connections are supported, this is not needed
+  // and the global config is used instead.
   awsClientConfig?: AwsClientConfiguration;
 
   isInitialized: () => Promise<boolean>;

--- a/src/target/connect-target.ts
+++ b/src/target/connect-target.ts
@@ -1,3 +1,5 @@
+import { AwsClientConfiguration } from '#src/aws/common/aws-client.js';
+
 import { getSecurityGroups } from '../aws/ec2/get-security-groups.js';
 import {
   AwsSecurityGroup,
@@ -11,6 +13,10 @@ import { TargetNotInitializedError } from './target-errors.js';
 import { TARGET_ACCESS_SECURITY_GROUP_NAME_PREFIX } from './target-input.js';
 
 export interface ConnectTarget {
+  // Per-target AWS client config can only be specified via config file.
+  // In interactive mode as well as with CLI arguments, global client config is used.
+  awsClientConfig?: AwsClientConfiguration;
+
   isInitialized: () => Promise<boolean>;
 
   getBastionId: () => Promise<string>;
@@ -19,7 +25,17 @@ export interface ConnectTarget {
   getPort: () => Promise<number>;
 }
 
+export interface ConnectTargetBaseConstructorInput {
+  awsClientConfig?: AwsClientConfiguration;
+}
+
 export abstract class ConnectTargetBase implements ConnectTarget {
+  awsClientConfig?: AwsClientConfiguration;
+
+  constructor({ awsClientConfig }: ConnectTargetBaseConstructorInput = {}) {
+    this.awsClientConfig = awsClientConfig;
+  }
+
   async isInitialized(): Promise<boolean> {
     const accessSecurityGroup = await this.getAccessSecurityGroup();
     return accessSecurityGroup !== undefined;

--- a/src/target/create-connect-target.ts
+++ b/src/target/create-connect-target.ts
@@ -1,8 +1,9 @@
-import { ConnectTarget } from './connect-target.js';
 import { CustomConnectTarget } from './custom/custom-connect-target.js';
 import { DbClusterConnectTarget } from './db-cluster/db-cluster-connect-target.js';
 import { DbInstanceConnectTarget } from './db-instance/db-instance-connect-target.js';
-import { ConnectTargetInput } from './target-input.js';
+
+import type { ConnectTarget } from './connect-target.js';
+import type { ConnectTargetInput } from './target-input.js';
 
 export function createConnectTarget(target: ConnectTargetInput): ConnectTarget {
   if ('dbInstance' in target) {

--- a/src/target/create-connect-target.ts
+++ b/src/target/create-connect-target.ts
@@ -11,5 +11,5 @@ export function createConnectTarget(target: ConnectTargetInput): ConnectTarget {
   if ('dbCluster' in target) {
     return new DbClusterConnectTarget(target);
   }
-  return new CustomConnectTarget(target.custom);
+  return new CustomConnectTarget(target);
 }

--- a/src/target/create-init-target.ts
+++ b/src/target/create-init-target.ts
@@ -1,8 +1,9 @@
 import { CustomInitTarget } from './custom/custom-init-target.js';
 import { DbClusterInitTarget } from './db-cluster/db-cluster-init-target.js';
 import { DbInstanceInitTarget } from './db-instance/db-instance-init-target.js';
-import { InitTarget } from './init-target.js';
-import { InitTargetInput } from './target-input.js';
+
+import type { InitTarget } from './init-target.js';
+import type { InitTargetInput } from './target-input.js';
 
 export function createInitTarget(target: InitTargetInput): InitTarget {
   if ('dbInstance' in target) {

--- a/src/target/custom/custom-connect-target.ts
+++ b/src/target/custom/custom-connect-target.ts
@@ -1,25 +1,32 @@
+import { AwsClientConfiguration } from '#src/aws/common/aws-client.js';
 import { getBastion } from '#src/bastion/get-bastion.js';
 
 import { ConnectTarget } from '../connect-target.js';
 import { TargetNotInitializedError } from '../target-errors.js';
 
 export class CustomConnectTarget implements ConnectTarget {
+  readonly awsClientConfig?: AwsClientConfiguration;
+
   private readonly vpcId: string;
   private readonly host: string;
   private readonly port: number;
 
   constructor({
-    vpcId,
-    host,
-    port,
+    custom: { vpcId, host, port },
+    awsClientConfig,
   }: {
-    vpcId: string;
-    host: string;
-    port: number;
+    custom: {
+      vpcId: string;
+      host: string;
+      port: number;
+    };
+    awsClientConfig?: AwsClientConfiguration;
   }) {
     this.vpcId = vpcId;
     this.host = host;
     this.port = port;
+
+    this.awsClientConfig = awsClientConfig;
   }
 
   async isInitialized(): Promise<boolean> {

--- a/src/target/custom/custom-connect-target.ts
+++ b/src/target/custom/custom-connect-target.ts
@@ -1,8 +1,9 @@
-import { AwsClientConfiguration } from '#src/aws/common/aws-client.js';
+import type { AwsClientConfiguration } from '#src/aws/common/aws-client.js';
 import { getBastion } from '#src/bastion/get-bastion.js';
 
-import { ConnectTarget } from '../connect-target.js';
 import { TargetNotInitializedError } from '../target-errors.js';
+
+import type { ConnectTarget } from '../connect-target.js';
 
 export class CustomConnectTarget implements ConnectTarget {
   readonly awsClientConfig?: AwsClientConfiguration;

--- a/src/target/custom/custom-init-target.ts
+++ b/src/target/custom/custom-init-target.ts
@@ -1,6 +1,6 @@
 import { getBastion } from '#src/bastion/get-bastion.js';
 
-import { InitTarget } from '../init-target.js';
+import type { InitTarget } from '../init-target.js';
 
 export class CustomInitTarget implements InitTarget {
   private readonly vpcId: string;

--- a/src/target/db-cluster/db-cluster-connect-target.ts
+++ b/src/target/db-cluster/db-cluster-connect-target.ts
@@ -1,13 +1,18 @@
 import { AwsDbCluster } from '#src/aws/rds/rds-types.js';
 
-import { ConnectTargetBase } from '../connect-target.js';
+import {
+  ConnectTargetBase,
+  ConnectTargetBaseConstructorInput,
+} from '../connect-target.js';
 
 export class DbClusterConnectTarget extends ConnectTargetBase {
   private readonly dbCluster: AwsDbCluster;
 
-  constructor({ dbCluster }: { dbCluster: AwsDbCluster }) {
-    super();
-    this.dbCluster = dbCluster;
+  constructor(
+    input: ConnectTargetBaseConstructorInput & { dbCluster: AwsDbCluster }
+  ) {
+    super(input);
+    this.dbCluster = input.dbCluster;
   }
 
   async getHost(): Promise<string> {

--- a/src/target/db-cluster/db-cluster-connect-target.ts
+++ b/src/target/db-cluster/db-cluster-connect-target.ts
@@ -1,9 +1,8 @@
-import { AwsDbCluster } from '#src/aws/rds/rds-types.js';
+import type { AwsDbCluster } from '#src/aws/rds/rds-types.js';
 
-import {
-  ConnectTargetBase,
-  ConnectTargetBaseConstructorInput,
-} from '../connect-target.js';
+import { ConnectTargetBase } from '../connect-target.js';
+
+import type { ConnectTargetBaseConstructorInput } from '../connect-target.js';
 
 export class DbClusterConnectTarget extends ConnectTargetBase {
   private readonly dbCluster: AwsDbCluster;

--- a/src/target/db-cluster/db-cluster-init-target.ts
+++ b/src/target/db-cluster/db-cluster-init-target.ts
@@ -1,6 +1,6 @@
 import { getDbSubnetGroup } from '#src/aws/rds/get-db-subnet-group.js';
 import { modifyDBCluster } from '#src/aws/rds/modify-db-cluster.js';
-import { AwsDbCluster } from '#src/aws/rds/rds-types.js';
+import type { AwsDbCluster } from '#src/aws/rds/rds-types.js';
 
 import { InitTargetBase } from '../init-target.js';
 

--- a/src/target/db-instance/db-instance-connect-target.ts
+++ b/src/target/db-instance/db-instance-connect-target.ts
@@ -1,9 +1,8 @@
-import { AwsDbInstance } from '#src/aws/rds/rds-types.js';
+import type { AwsDbInstance } from '#src/aws/rds/rds-types.js';
 
-import {
-  ConnectTargetBase,
-  ConnectTargetBaseConstructorInput,
-} from '../connect-target.js';
+import { ConnectTargetBase } from '../connect-target.js';
+
+import type { ConnectTargetBaseConstructorInput } from '../connect-target.js';
 
 export class DbInstanceConnectTarget extends ConnectTargetBase {
   private readonly dbInstance: AwsDbInstance;

--- a/src/target/db-instance/db-instance-connect-target.ts
+++ b/src/target/db-instance/db-instance-connect-target.ts
@@ -1,13 +1,18 @@
 import { AwsDbInstance } from '#src/aws/rds/rds-types.js';
 
-import { ConnectTargetBase } from '../connect-target.js';
+import {
+  ConnectTargetBase,
+  ConnectTargetBaseConstructorInput,
+} from '../connect-target.js';
 
 export class DbInstanceConnectTarget extends ConnectTargetBase {
   private readonly dbInstance: AwsDbInstance;
 
-  constructor({ dbInstance }: { dbInstance: AwsDbInstance }) {
-    super();
-    this.dbInstance = dbInstance;
+  constructor(
+    input: ConnectTargetBaseConstructorInput & { dbInstance: AwsDbInstance }
+  ) {
+    super(input);
+    this.dbInstance = input.dbInstance;
   }
 
   async getHost(): Promise<string> {

--- a/src/target/db-instance/db-instance-init-target.ts
+++ b/src/target/db-instance/db-instance-init-target.ts
@@ -1,5 +1,5 @@
 import { modifyDbInstance } from '#src/aws/rds/modify-db-instance.js';
-import { AwsDbInstance } from '#src/aws/rds/rds-types.js';
+import type { AwsDbInstance } from '#src/aws/rds/rds-types.js';
 
 import { InitTargetBase } from '../init-target.js';
 

--- a/src/target/init-target.ts
+++ b/src/target/init-target.ts
@@ -1,7 +1,5 @@
 import { createSecurityGroup } from '../aws/ec2/create-security-group.js';
 import { getSecurityGroups } from '../aws/ec2/get-security-groups.js';
-import { AwsSecurityGroup } from '../aws/ec2/types/aws-security-group.js';
-import { Bastion } from '../bastion/bastion.js';
 import { generateShortId } from '../common/short-id.js';
 
 import {
@@ -9,6 +7,9 @@ import {
   AccessSecurityGroupAttachmentError,
 } from './target-errors.js';
 import { TARGET_ACCESS_SECURITY_GROUP_NAME_PREFIX } from './target-input.js';
+
+import type { Bastion } from '../bastion/bastion.js';
+import type { AwsSecurityGroup } from '../aws/ec2/types/aws-security-group.js';
 
 interface InitTargetAllowAccessHooks {
   onCreatingSecurityGroup?: () => void;

--- a/src/target/target-input.ts
+++ b/src/target/target-input.ts
@@ -1,3 +1,5 @@
+import { AwsClientConfiguration } from '#src/aws/common/aws-client.js';
+
 import { AwsDbCluster, AwsDbInstance } from '../aws/rds/rds-types.js';
 
 export type InitTargetInput =
@@ -5,10 +7,13 @@ export type InitTargetInput =
   | DbInstanceTargetInput
   | CustomInitTargetInput;
 
-export type ConnectTargetInput =
+export type ConnectTargetInput = (
   | DbClusterTargetInput
   | DbInstanceTargetInput
-  | CustomConnectTargetInput;
+  | CustomConnectTargetInput
+) & {
+  awsClientConfig?: AwsClientConfiguration;
+};
 
 export interface DbClusterTargetInput {
   dbCluster: AwsDbCluster;

--- a/src/target/target-input.ts
+++ b/src/target/target-input.ts
@@ -1,6 +1,6 @@
-import { AwsClientConfiguration } from '#src/aws/common/aws-client.js';
+import type { AwsClientConfiguration } from '#src/aws/common/aws-client.js';
 
-import { AwsDbCluster, AwsDbInstance } from '../aws/rds/rds-types.js';
+import type { AwsDbCluster, AwsDbInstance } from '../aws/rds/rds-types.js';
 
 export type InitTargetInput =
   | DbClusterTargetInput


### PR DESCRIPTION
### Summary

This PR introduces Basti configuration file. Users can define connection targets and connections (target + local port (more will be added)) in the file and use them with the `basti connect <connection>` command.

### Config file example


```yaml
# - Connections are used with the `basti connect <connection>` command
# - Targets' fields are the same as the options for the `basti connect` command
connections:
  database-dev:
    target:
      rdsInstance: my-dev-database
      awsProfile: dev
    localPort: 5432

  database-prod:
    target:
      rdsInstance: my-prod-database
      awsProfile: prod
    localPort: 5432

  # Default AWS profile and region are used if not specified in the target
  aurora-cluster-dev:
    target:
      rdsCluster: my-prod-aurora-cluster
    localPort: 5432

  custom-target:
    target: custom-target
    localPort: 4647

  # Same target but with different local port
  custom-target-local:
    target: custom-target
    localPort: 4646

# Targets can be extracted and reused in multiple connections
# with different local ports
targets:
  custom-target:
    customTargetVpc: vpc-1234567890
    customTargetHost: 10.0.1.1
    customTargetPort: 4646
    awsProfile: prod
    awsRegion: us-east-1
```

### TODO

- [x] Check conflicting CLI options
- [x] Config file and CLI arguments merging - The config options won't be merged with command line arguments to avoid possible user confusion.
- [x] Documentation

### References

closes #16