### PR TITLE
chore: make IMDSv2 required on instance creation

### DIFF
--- a/src/aws/ec2/create-ec2-instance.ts
+++ b/src/aws/ec2/create-ec2-instance.ts
@@ -29,6 +29,8 @@ export interface CreateEc2InstanceInput {
 
   userData?: string;
 
+  requireIMDSv2?: boolean;
+
   tags: AwsTag[];
 }
 
@@ -42,6 +44,7 @@ export async function createEc2Instance({
   assignPublicIp,
   securityGroupIds,
   userData,
+  requireIMDSv2,
   tags,
 }: CreateEc2InstanceInput): Promise<AwsEc2Instance> {
   const instanceProfile = await createIamInstanceProfile({
@@ -74,6 +77,10 @@ export async function createEc2Instance({
             userData !== undefined
               ? Buffer.from(userData).toString('base64')
               : undefined,
+
+          MetadataOptions: {
+            HttpTokens: requireIMDSv2 === true ? 'required' : 'optional',
+          },
 
           TagSpecifications: [
             {

--- a/src/bastion/create-bastion.ts
+++ b/src/bastion/create-bastion.ts
@@ -187,6 +187,7 @@ async function createBastionInstance(
       assignPublicIp: true,
       securityGroupIds: [bastionSecurityGroup.id],
       userData: BASTION_INSTANCE_CLOUD_INIT,
+      requireIMDSv2: true,
       tags: [
         {
           key: BASTION_INSTANCE_ID_TAG_NAME,


### PR DESCRIPTION
### Summary

In v1.2.1, Basti `stop-in-not-used.sh` script was migrated to IMDSv2. This PR makes IMDSv2 usage required for the Basti EC2 instance to comply with security audits (like [Vanta](https://www.vanta.com/)) without manual intervention.