### PR TITLE
fix: make top-level configuration values optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "basti",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Basti is a CLI tool for accessing DB instances and other AWS resources in private networks almost at no cost.",
   "author": "BohdanPetryshyn",
   "homepage": "https://github.com/BohdanPetryshyn/basti#readme",

--- a/src/cli/config/config-parser.ts
+++ b/src/cli/config/config-parser.ts
@@ -49,8 +49,8 @@ const ConnectionConfigParser = z.object({
 export type ConnectionConfig = z.infer<typeof ConnectionConfigParser>;
 
 export const ConfigParser = z.object({
-  connections: z.record(z.string(), ConnectionConfigParser),
-  targets: z.record(z.string(), ConnectionTargetConfigParser),
+  connections: z.record(z.string(), ConnectionConfigParser).optional(),
+  targets: z.record(z.string(), ConnectionTargetConfigParser).optional(),
 });
 export type Config = z.infer<typeof ConfigParser>;
 

--- a/src/cli/config/get-command-input.ts
+++ b/src/cli/config/get-command-input.ts
@@ -19,7 +19,7 @@ export function getConnectCommandInputFromConfig(
     });
   }
 
-  const connectionConfig = config.connections[connection];
+  const connectionConfig = config.connections?.[connection];
 
   if (!connectionConfig) {
     throw OperationError.fromErrorMessage({
@@ -31,7 +31,7 @@ export function getConnectCommandInputFromConfig(
   const connectionTarget =
     typeof connectionConfig.target === 'object'
       ? connectionConfig.target
-      : config.targets[connectionConfig.target];
+      : config.targets?.[connectionConfig.target];
 
   if (!connectionTarget) {
     throw OperationError.fromErrorMessage({


### PR DESCRIPTION
### Summary
This PR makes `connections` and `targets` configuration fields optional. A configuration file may have no `targets` field if all the targets are inlined in the connections.