### PR TITLE
chore: support dot configuraiton file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ dist
 .history
 .DS_Store
 .build-deps-tmp
-basti.yaml
+.basti.yaml

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ as well as other Basti settings  -->
 When dealing with multiple connection targets, it becomes convenient to store their configurations
 and other Basti settings in a dedicated configuration file. To facilitate this, Basti automatically 
 searches for the configuration file in the current directory and its parent directories. 
-The supported file formats are `basti.yaml`, `basti.yml`, and `basti.json`.
+The supported file names are `.basti.yaml`, `.basti.yml`, and `.basti.json`.
 
 You can quickly start a connection defined in the configuration file by passing its
 name to the `basti connect` command:

--- a/src/cli/config/get-config.ts
+++ b/src/cli/config/get-config.ts
@@ -9,7 +9,14 @@ import type { Config } from './config-parser.js';
 
 export async function getConfig(): Promise<Config | undefined> {
   const configExplorer = cosmiconfig('basti', {
-    searchPlaces: ['basti.yaml', 'basti.yml', 'basti.json'],
+    searchPlaces: [
+      '.basti.yaml',
+      '.basti.yml',
+      '.basti.json',
+      'basti.yaml',
+      'basti.yml',
+      'basti.json',
+    ],
   });
   const configResult = await configExplorer.search();
 


### PR DESCRIPTION
### Summary

This PR extends the list of supported configuration file names with `.basti.yaml`, `.basti.yml`, `.basti.json`. The documentation now recommends using these names instead of the ones without the leading dot. Files with leading dots a considered hidden by the operating systems which is useful when setting up global basti config in the home directory.