### PR TITLE
fix: retry spawning session manager

### DIFF
--- a/src/common/child-process.ts
+++ b/src/common/child-process.ts
@@ -34,6 +34,10 @@ export class OutputOptimizedChildProcess {
     return this;
   }
 
+  kill(): void {
+    this.process.kill();
+  }
+
   onExit(
     listener: (exitDescription: ChildProcessExitDescription) => void
   ): this {
@@ -55,12 +59,22 @@ export class OutputOptimizedChildProcess {
   collectErrorOutput(): string {
     return this.errorOutput.join('\n');
   }
+
+  collectAllOutput(): ChildProcessOutput {
+    return {
+      output: this.collectOutput(),
+      errorOutput: this.collectErrorOutput(),
+    };
+  }
 }
 
-export interface ChildProcessExitDescription {
-  readonly reason: number | NodeJS.Signals;
+export interface ChildProcessOutput {
   readonly output: string;
   readonly errorOutput: string;
+}
+
+export interface ChildProcessExitDescription extends ChildProcessOutput {
+  readonly reason: number | NodeJS.Signals;
 }
 
 export function spawnProcess(

--- a/src/common/debug.ts
+++ b/src/common/debug.ts
@@ -3,6 +3,9 @@ export function setUpDebugMode(): void {
     return;
   }
 
+  console.log('>>>         Basti is running in debug mode         <<<');
+  console.log('>>> Visual glitches are possible due to debug logs <<<');
+
   Error.stackTraceLimit = Number.POSITIVE_INFINITY;
 }
 

--- a/src/common/retry.ts
+++ b/src/common/retry.ts
@@ -1,3 +1,6 @@
+import { cli } from './cli.js';
+import { getErrorMessage } from './runtime-errors.js';
+
 export interface RetryConfig {
   delay: number;
   maxRetries: number;
@@ -24,6 +27,7 @@ export async function retry<T>(
     } catch (error) {
       if (retries < config.maxRetries && config.shouldRetry(error)) {
         retries++;
+        cli.debug(`Retrying after error: ${getErrorMessage(error)}`);
         await delay(config.delay);
       } else {
         throw error;

--- a/src/session/session-errors.ts
+++ b/src/session/session-errors.ts
@@ -1,4 +1,7 @@
-import type { ChildProcessExitDescription } from '#src/common/child-process.js';
+import type {
+  ChildProcessExitDescription,
+  ChildProcessOutput,
+} from '#src/common/child-process.js';
 import { RuntimeError } from '#src/common/runtime-errors.js';
 
 export class SessionManagerPluginNonInstalledError extends RuntimeError {
@@ -20,5 +23,17 @@ export class SessionManagerPluginExitError extends RuntimeError {
     super('session-manager-plugin exited unexpectedly');
 
     this.exitDescription = exitDescription;
+  }
+}
+
+export class SessionManagerPluginTimeoutError extends RuntimeError {
+  readonly output: ChildProcessOutput;
+
+  constructor(output: ChildProcessOutput) {
+    super(
+      `session-manager-plugin did not start the port forwarding session. \nOutput:\n ${output.output} \n\nError Output:\n ${output.errorOutput}`
+    );
+
+    this.output = output;
   }
 }


### PR DESCRIPTION
### Summary

Sometimes, `session-manager-plugin` doesn't start the port forwarding session and just hangs up. This was leading to Basti never showing the success message and the port forwarding session itself never starting.

This PR introduces a timeout for the `session-manager-plugin` to start a session. If the session is not started in 30 seconds, the plugin is killed and restarted in 1 second.