### PR TITLE
chore(basti-cdk): build process improvements

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,7 @@
 node_modules
 dist
 .history
+.prettierrc.js
+.prettierrc.cjs
+jest.config.js
+jest.config.cjs

--- a/packages/basti-cdk/.eslintrc.json
+++ b/packages/basti-cdk/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../.eslintrc.json"]
+}

--- a/packages/basti-cdk/.npmignore
+++ b/packages/basti-cdk/.npmignore
@@ -13,3 +13,7 @@ dist
 # Include .jsii and .jsii.gz
 !.jsii
 !.jsii.gz
+
+
+# Exclude jsii outdir
+dist/packages

--- a/packages/basti-cdk/.npmignore
+++ b/packages/basti-cdk/.npmignore
@@ -14,6 +14,5 @@ dist
 !.jsii
 !.jsii.gz
 
-
 # Exclude jsii outdir
 dist/packages

--- a/packages/basti-cdk/.prettierrc.js
+++ b/packages/basti-cdk/.prettierrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  ...require('../../.prettierrc.js'),
+};

--- a/packages/basti-cdk/jest.config.js
+++ b/packages/basti-cdk/jest.config.js
@@ -1,8 +1,5 @@
-// eslint-disable-next-line unicorn/prefer-module
+/** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  roots: ['.'],
-  testMatch: ['**/**.test.ts'],
-  transform: {
-    '^.+\\.tsx?$': 'ts-jest',
-  },
+  preset: 'ts-jest',
+  testEnvironment: 'node',
 };

--- a/packages/basti-cdk/package.json
+++ b/packages/basti-cdk/package.json
@@ -12,7 +12,8 @@
       "email": "veringabob@gmail.com"
     }
   ],
-  "main": "src/index.js",
+  "main": "dist/js/index.js",
+  "types": "dist/js/index.d.ts",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/BohdanPetryshyn/basti.git"
@@ -25,15 +26,19 @@
     "watch": "tsc -w"
   },
   "stability": "stable",
-  "types": "src/index.d.ts",
   "jsii": {
-    "outdir": "dist",
+    "outdir": "dist/packages",
     "versionFormat": "full",
     "targets": {
       "python": {
         "distName": "basti-cdk",
         "module": "basti_cdk"
       }
+    },
+    "tsc": {
+      "rootDir": "src",
+      "outDir": "dist/js",
+      "forceConsistentCasingInFileNames": true
     }
   },
   "devDependencies": {

--- a/packages/basti-cdk/package.json
+++ b/packages/basti-cdk/package.json
@@ -26,9 +26,12 @@
   "types": "dist/js/index.d.ts",
   "stability": "stable",
   "scripts": {
-    "test": "jest",
+    "test": "npm run check && jest",
     "build": "jsii",
     "build:watch": "jsii --watch",
+    "check": "npm run check-types && npm run check-style",
+    "check-types": "tsc --noEmit",
+    "check-style": "eslint src",
     "package": "jsii-pacmak"
   },
   "peerDependencies": {

--- a/packages/basti-cdk/package.json
+++ b/packages/basti-cdk/package.json
@@ -12,20 +12,39 @@
       "email": "veringabob@gmail.com"
     }
   ],
+  "homepage": "https://github.com/BohdanPetryshyn/basti/tree/main/packages/basti-cdk",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BohdanPetryshyn/basti.git",
+    "directory": "packages/basti-cdk"
+  },
+  "bugs": {
+    "url": "https://github.com/BohdanPetryshyn/basti/issues"
+  },
+  "license": "MIT",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",
-  "license": "MIT",
-  "repository": {
-    "url": "https://github.com/BohdanPetryshyn/basti.git"
-  },
+  "stability": "stable",
   "scripts": {
+    "test": "jest",
     "build": "jsii",
     "build:watch": "jsii --watch",
-    "package": "jsii-pacmak",
-    "test": "tsc && jest",
-    "watch": "tsc -w"
+    "package": "jsii-pacmak"
   },
-  "stability": "stable",
+  "peerDependencies": {
+    "aws-cdk-lib": "2.86.0",
+    "constructs": "10.0.5"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.3",
+    "@types/node": "^20.4.2",
+    "aws-cdk-lib": "2.86.0",
+    "constructs": "10.0.5",
+    "jest": "^29.6.1",
+    "jsii": "^5.1.8",
+    "jsii-pacmak": "^1.85.0",
+    "ts-jest": "^29.1.1"
+  },
   "jsii": {
     "outdir": "dist/packages",
     "versionFormat": "full",
@@ -40,19 +59,5 @@
       "outDir": "dist/js",
       "forceConsistentCasingInFileNames": true
     }
-  },
-  "devDependencies": {
-    "@types/jest": "^29.5.3",
-    "@types/node": "^20.4.2",
-    "aws-cdk-lib": "2.86.0",
-    "constructs": "10.0.5",
-    "jest": "^29.6.1",
-    "jsii": "^5.1.8",
-    "jsii-pacmak": "^1.85.0",
-    "ts-jest": "^29.1.1"
-  },
-  "peerDependencies": {
-    "aws-cdk-lib": "2.86.0",
-    "constructs": "10.0.5"
   }
 }

--- a/packages/basti-cdk/src/__test__/basti-access-security-group.test.ts
+++ b/packages/basti-cdk/src/__test__/basti-access-security-group.test.ts
@@ -2,7 +2,8 @@ import * as cdk from 'aws-cdk-lib';
 import { aws_ec2, aws_rds } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 
-import { BastiAccessSecurityGroup, BastiInstance } from '../src';
+import { BastiAccessSecurityGroup } from '../basti-access-security-group';
+import { BastiInstance } from '../basti-instance';
 
 describe('BastiAccessSecurityGroupTest', () => {
   test('normal-access-security-group', () => {

--- a/packages/basti-cdk/src/__test__/basti-helper.test.ts
+++ b/packages/basti-cdk/src/__test__/basti-helper.test.ts
@@ -1,4 +1,4 @@
-import { generateShortId } from '../src/basti-helper';
+import { generateShortId } from '../basti-helper';
 
 describe('BastiHelperTest', () => {
   test('generate-short-solutions', () => {

--- a/packages/basti-cdk/src/__test__/basti-instance.test.ts
+++ b/packages/basti-cdk/src/__test__/basti-instance.test.ts
@@ -3,7 +3,7 @@ import * as cdk from 'aws-cdk-lib';
 import { aws_ec2, aws_iam } from 'aws-cdk-lib';
 import { InstanceClass, InstanceSize } from 'aws-cdk-lib/aws-ec2';
 
-import { BastiInstance } from '../src';
+import { BastiInstance } from '../basti-instance';
 
 describe('BastiInstanceTest', () => {
   test('basic-construct', () => {

--- a/packages/basti/package.json
+++ b/packages/basti/package.json
@@ -6,7 +6,8 @@
   "homepage": "https://github.com/BohdanPetryshyn/basti",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/BohdanPetryshyn/basti.git"
+    "url": "git+https://github.com/BohdanPetryshyn/basti.git",
+    "directory": "packages/basti"
   },
   "bugs": {
     "url": "https://github.com/BohdanPetryshyn/basti/issues"


### PR DESCRIPTION
## Proposed Changes

This PR introduces a few build process changes/improvements:

1. JS files produced by the `jsii` command now reside in the `dist/js` folder
2. Language-specific packages produced by the `jsii-pacmak` command now reside in `dist/packages` folder
3. Unit tests will now reside in the `src` folder in `__test__` subfolders. This change is mostly forced by the dynamic `tsconfig.json` file produced by `jsii`
4. `packages.json` consistency with the `packages/basti/package.json` is improved
5. package-specific Prettier and Eslint configs were added

## Related Issue

#48

## Checklist

- [x] All the tests and checks passed (`npm run test`).
- [x] I have added necessary documentation and/or updated existing documentation. <!-- check if not applicable -->
- [x] I have added or modified tests to cover the changes. <!-- check if not applicable -->

cc @bobveringa

