### PR TITLE
feat: resource tags as cli arguments

### DIFF
--- a/src/aws/ec2/create-ec2-instance.ts
+++ b/src/aws/ec2/create-ec2-instance.ts
@@ -34,7 +34,7 @@ export interface CreateEc2InstanceInput {
   requireIMDSv2?: boolean;
 
   instanceTags: AwsTag[];
-  tags?: AwsTag[];
+  tags: AwsTag[];
 }
 
 export async function createEc2Instance({
@@ -92,7 +92,8 @@ export async function createEc2Instance({
               ResourceType: 'instance',
               Tags: [
                 ...instanceTags.map(element => toTagCreateInput(element)),
-                ...(tags ? tags.map(element => toTagCreateInput(element)) : []),
+                ...tags.map(element => toTagCreateInput(element)),
+                toTagCreateInput({ key: 'Name', value: name }),
               ],
             },
           ],

--- a/src/aws/ec2/create-ec2-instance.ts
+++ b/src/aws/ec2/create-ec2-instance.ts
@@ -51,6 +51,8 @@ export async function createEc2Instance({
   instanceTags,
   tags,
 }: CreateEc2InstanceInput): Promise<AwsEc2Instance> {
+  const tagsWithName = [...tags, { key: 'Name', value: name }];
+
   const instanceProfile = await createIamInstanceProfile({
     name,
     roleNames,
@@ -88,19 +90,9 @@ export async function createEc2Instance({
           },
 
           TagSpecifications: [
-            toTagSpecification('instance', [
-              ...instanceTags,
-              ...tags,
-              { key: 'Name', value: name },
-            ]),
-            toTagSpecification('volume', [
-              ...tags,
-              { key: 'Name', value: name },
-            ]),
-            toTagSpecification('network-interface', [
-              ...tags,
-              { key: 'Name', value: name },
-            ]),
+            toTagSpecification('instance', [...instanceTags, ...tagsWithName]),
+            toTagSpecification('volume', tagsWithName),
+            toTagSpecification('network-interface', tagsWithName),
           ],
 
           MinCount: 1,

--- a/src/aws/ec2/create-security-group.ts
+++ b/src/aws/ec2/create-security-group.ts
@@ -21,7 +21,7 @@ export interface CreateSecurityGroupInput {
   description: string;
   vpcId: string;
   ingressRules: SecurityGroupIngressRule[];
-  tags?: AwsTag[];
+  tags: AwsTag[];
 }
 
 export async function createSecurityGroup({
@@ -36,7 +36,7 @@ export async function createSecurityGroup({
       GroupName: name,
       Description: description,
       VpcId: vpcId,
-      TagSpecifications: tags?.map(tag => ({
+      TagSpecifications: tags.map(tag => ({
         ResourceType: 'security-group',
         Tags: [{ Key: tag.key, Value: tag.value }],
       })),
@@ -60,7 +60,7 @@ export async function createSecurityGroup({
       new AuthorizeSecurityGroupIngressCommand({
         GroupId,
         IpPermissions: ingressRules.map(rule => toIpPermission(rule)),
-        TagSpecifications: tags?.map(tag => ({
+        TagSpecifications: tags.map(tag => ({
           ResourceType: 'security-group-rule',
           Tags: [{ Key: tag.key, Value: tag.value }],
         })),

--- a/src/aws/ec2/create-security-group.ts
+++ b/src/aws/ec2/create-security-group.ts
@@ -6,6 +6,7 @@ import {
 
 import { COMMON_WAITER_CONFIG } from '../common/waiter-config.js';
 import { handleWaiterError } from '../common/waiter-error.js';
+import { toTagSpecification } from '../tags/utils/to-tag-specification.js';
 
 import { ec2Client } from './ec2-client.js';
 
@@ -36,10 +37,12 @@ export async function createSecurityGroup({
       GroupName: name,
       Description: description,
       VpcId: vpcId,
-      TagSpecifications: tags.map(tag => ({
-        ResourceType: 'security-group',
-        Tags: [{ Key: tag.key, Value: tag.value }],
-      })),
+      TagSpecifications: [
+        toTagSpecification('security-group', [
+          ...tags,
+          { key: 'Name', value: name },
+        ]),
+      ],
     })
   );
 
@@ -60,10 +63,7 @@ export async function createSecurityGroup({
       new AuthorizeSecurityGroupIngressCommand({
         GroupId,
         IpPermissions: ingressRules.map(rule => toIpPermission(rule)),
-        TagSpecifications: tags.map(tag => ({
-          ResourceType: 'security-group-rule',
-          Tags: [{ Key: tag.key, Value: tag.value }],
-        })),
+        TagSpecifications: [toTagSpecification('security-group-rule', tags)],
       })
     );
   }

--- a/src/aws/ec2/create-security-group.ts
+++ b/src/aws/ec2/create-security-group.ts
@@ -39,7 +39,12 @@ export async function createSecurityGroup({
       GroupName: name,
       Description: description,
       VpcId: vpcId,
-      TagSpecifications: [toTagSpecification('security-group', tags)],
+      TagSpecifications: [
+        toTagSpecification('security-group', [
+          ...tags,
+          { key: 'Name', value: name },
+        ]),
+      ],
     })
   );
 

--- a/src/aws/ec2/create-security-group.ts
+++ b/src/aws/ec2/create-security-group.ts
@@ -37,12 +37,8 @@ export async function createSecurityGroup({
       GroupName: name,
       Description: description,
       VpcId: vpcId,
-      TagSpecifications: [
-        toTagSpecification('security-group', [
-          ...tags,
-          { key: 'Name', value: name },
-        ]),
-      ],
+      // TODO: Add tags to the egress rule
+      TagSpecifications: [toTagSpecification('security-group', tags)],
     })
   );
 

--- a/src/aws/iam/create-iam-role.ts
+++ b/src/aws/iam/create-iam-role.ts
@@ -8,6 +8,7 @@ import { attachIamPolicy } from './attach-iam-policy.js';
 import { iamClient } from './iam-client.js';
 import { parseRoleResponse } from './parse-iam-response.js';
 
+import type { AwsTag } from '../tags/types.js';
 import type { AwsRole } from './types.js';
 
 export interface InlinePolicyInput {
@@ -21,6 +22,7 @@ export interface CreateIamRoleInput {
   principalService: string;
   managedPolicies?: string[];
   inlinePolicies?: InlinePolicyInput[];
+  tags?: AwsTag[];
 }
 
 export async function createIamRole({
@@ -29,6 +31,7 @@ export async function createIamRole({
   principalService,
   managedPolicies,
   inlinePolicies,
+  tags,
 }: CreateIamRoleInput): Promise<AwsRole> {
   const { Role } = await iamClient.send(
     new CreateRoleCommand({
@@ -36,6 +39,7 @@ export async function createIamRole({
       Path: path,
       AssumeRolePolicyDocument:
         formatAssumeRolePolicyDocument(principalService),
+      Tags: tags?.map(tag => ({ Key: tag.key, Value: tag.value })),
     })
   );
 

--- a/src/aws/iam/create-instance-profile.ts
+++ b/src/aws/iam/create-instance-profile.ts
@@ -10,23 +10,27 @@ import { handleWaiterError } from '../common/waiter-error.js';
 import { iamClient } from './iam-client.js';
 import { parseIamInstanceProfileResponse } from './parse-iam-response.js';
 
+import type { AwsTag } from '../tags/types.js';
 import type { AwsIamInstanceProfile } from './types.js';
 
 export interface CreateInstanceProfileInput {
   name: string;
   roleNames: string[];
   path: string;
+  tags?: AwsTag[];
 }
 
 export async function createIamInstanceProfile({
   name,
   roleNames,
   path,
+  tags,
 }: CreateInstanceProfileInput): Promise<AwsIamInstanceProfile> {
   const { InstanceProfile } = await iamClient.send(
     new CreateInstanceProfileCommand({
       InstanceProfileName: name,
       Path: path,
+      Tags: tags?.map(tag => ({ Key: tag.key, Value: tag.value })),
     })
   );
 

--- a/src/aws/iam/create-instance-profile.ts
+++ b/src/aws/iam/create-instance-profile.ts
@@ -17,7 +17,7 @@ export interface CreateInstanceProfileInput {
   name: string;
   roleNames: string[];
   path: string;
-  tags?: AwsTag[];
+  tags: AwsTag[];
 }
 
 export async function createIamInstanceProfile({
@@ -30,7 +30,7 @@ export async function createIamInstanceProfile({
     new CreateInstanceProfileCommand({
       InstanceProfileName: name,
       Path: path,
-      Tags: tags?.map(tag => ({ Key: tag.key, Value: tag.value })),
+      Tags: tags.map(tag => ({ Key: tag.key, Value: tag.value })),
     })
   );
 

--- a/src/aws/tags/utils/to-tag-specification.ts
+++ b/src/aws/tags/utils/to-tag-specification.ts
@@ -1,0 +1,15 @@
+import type { TagSpecification } from '@aws-sdk/client-ec2';
+import type { AwsTag } from '../types.js';
+
+export function toTagSpecification(
+  resourceType: string,
+  tags: AwsTag[]
+): TagSpecification {
+  return {
+    ResourceType: resourceType,
+    Tags: tags.map(tag => ({
+      Key: tag.key,
+      Value: tag.value,
+    })),
+  };
+}

--- a/src/bastion/create-bastion-role.ts
+++ b/src/bastion/create-bastion-role.ts
@@ -1,6 +1,7 @@
 import { createIamInlinePolicy } from '#src/aws/iam/create-iam-inline-policy.js';
 import { createIamRole } from '#src/aws/iam/create-iam-role.js';
 import type { AwsRole } from '#src/aws/iam/types.js';
+import type { AwsTag } from '#src/aws/tags/types.js';
 
 import {
   BASTION_INSTANCE_ROLE_NAME_PREFIX,
@@ -9,6 +10,7 @@ import {
 
 export interface CreateBastionRoleInput {
   bastionId: string;
+  tags?: AwsTag[];
 }
 
 export interface CreateBastionInlinePoliciesInput {
@@ -18,11 +20,13 @@ export interface CreateBastionInlinePoliciesInput {
 
 export async function createBastionRole({
   bastionId,
+  tags,
 }: CreateBastionRoleInput): Promise<AwsRole> {
   return await createIamRole({
     name: `${BASTION_INSTANCE_ROLE_NAME_PREFIX}-${bastionId}`,
     path: BASTION_INSTANCE_ROLE_PATH,
     principalService: 'ec2.amazonaws.com',
+    tags,
   });
 }
 

--- a/src/bastion/create-bastion-role.ts
+++ b/src/bastion/create-bastion-role.ts
@@ -10,7 +10,7 @@ import {
 
 export interface CreateBastionRoleInput {
   bastionId: string;
-  tags?: AwsTag[];
+  tags: AwsTag[];
 }
 
 export interface CreateBastionInlinePoliciesInput {

--- a/src/bastion/create-bastion.ts
+++ b/src/bastion/create-bastion.ts
@@ -45,7 +45,7 @@ interface CreateBastionHooks {
 export interface CreateBastionInput {
   vpcId: string;
   subnetId: string;
-  tags?: AwsTag[];
+  tags: AwsTag[];
   hooks?: CreateBastionHooks;
 }
 
@@ -122,7 +122,7 @@ async function getBastionImageId(hooks?: CreateBastionHooks): Promise<string> {
 
 async function createBastionRole(
   bastionId: string,
-  tags?: AwsTag[],
+  tags: AwsTag[],
   hooks?: CreateBastionHooks
 ): Promise<AwsRole> {
   try {
@@ -158,7 +158,7 @@ async function createBastionRoleInlinePolicies(
 async function createBastionSecurityGroup(
   bastionId: string,
   vpcId: string,
-  tags?: AwsTag[],
+  tags: AwsTag[],
   hooks?: CreateBastionHooks
 ): Promise<AwsSecurityGroup> {
   try {
@@ -184,7 +184,7 @@ async function createBastionInstance(
   bastionRole: AwsRole,
   subnetId: string,
   bastionSecurityGroup: AwsSecurityGroup,
-  tags?: AwsTag[],
+  tags: AwsTag[],
   hooks?: CreateBastionHooks
 ): Promise<AwsEc2Instance> {
   try {

--- a/src/bastion/create-bastion.ts
+++ b/src/bastion/create-bastion.ts
@@ -1,5 +1,7 @@
 import { InstanceStateName } from '@aws-sdk/client-ec2';
 
+import type { AwsTag } from '#src/aws/tags/types.js';
+
 import { createEc2Instance } from '../aws/ec2/create-ec2-instance.js';
 import { createSecurityGroup } from '../aws/ec2/create-security-group.js';
 import { getStringSsmParameter } from '../aws/ssm/get-ssm-parameter.js';
@@ -43,23 +45,26 @@ interface CreateBastionHooks {
 export interface CreateBastionInput {
   vpcId: string;
   subnetId: string;
+  tags?: AwsTag[];
   hooks?: CreateBastionHooks;
 }
 
 export async function createBastion({
   vpcId,
   subnetId,
+  tags,
   hooks,
 }: CreateBastionInput): Promise<Bastion> {
   const bastionId = generateShortId();
 
   const bastionImageId = await getBastionImageId(hooks);
 
-  const bastionRole = await createBastionRole(bastionId, hooks);
+  const bastionRole = await createBastionRole(bastionId, tags, hooks);
 
   const bastionSecurityGroup = await createBastionSecurityGroup(
     bastionId,
     vpcId,
+    tags,
     hooks
   );
 
@@ -69,6 +74,7 @@ export async function createBastion({
     bastionRole,
     subnetId,
     bastionSecurityGroup,
+    tags,
     hooks
   );
 
@@ -116,12 +122,14 @@ async function getBastionImageId(hooks?: CreateBastionHooks): Promise<string> {
 
 async function createBastionRole(
   bastionId: string,
+  tags?: AwsTag[],
   hooks?: CreateBastionHooks
 ): Promise<AwsRole> {
   try {
     hooks?.onCreatingRole?.();
     const bastionRole = await bastionRoleOps.createBastionRole({
       bastionId,
+      tags,
     });
     hooks?.onRoleCreated?.(bastionRole.name);
     return bastionRole;
@@ -150,6 +158,7 @@ async function createBastionRoleInlinePolicies(
 async function createBastionSecurityGroup(
   bastionId: string,
   vpcId: string,
+  tags?: AwsTag[],
   hooks?: CreateBastionHooks
 ): Promise<AwsSecurityGroup> {
   try {
@@ -159,6 +168,7 @@ async function createBastionSecurityGroup(
       description:
         'Identifies Basti instance and allows connection to the Internet',
       vpcId,
+      tags,
       ingressRules: [],
     });
     hooks?.onSecurityGroupCreated?.(bastionSecurityGroup.id);
@@ -174,6 +184,7 @@ async function createBastionInstance(
   bastionRole: AwsRole,
   subnetId: string,
   bastionSecurityGroup: AwsSecurityGroup,
+  tags?: AwsTag[],
   hooks?: CreateBastionHooks
 ): Promise<AwsEc2Instance> {
   try {
@@ -189,7 +200,7 @@ async function createBastionInstance(
       securityGroupIds: [bastionSecurityGroup.id],
       userData: BASTION_INSTANCE_CLOUD_INIT,
       requireIMDSv2: true,
-      tags: [
+      instanceTags: [
         {
           key: BASTION_INSTANCE_ID_TAG_NAME,
           value: bastionId,
@@ -199,6 +210,7 @@ async function createBastionInstance(
           value: new Date().toISOString(),
         },
       ],
+      tags,
     });
     hooks?.onInstanceCreated?.(bastionInstance.id);
     return bastionInstance;

--- a/src/cli/commands/init/allow-target-access.ts
+++ b/src/cli/commands/init/allow-target-access.ts
@@ -1,4 +1,5 @@
 import { AwsTooManySecurityGroupsAttachedError } from '#src/aws/rds/rds-errors.js';
+import type { AwsTag } from '#src/aws/tags/types.js';
 import type { Bastion } from '#src/bastion/bastion.js';
 import { cli } from '#src/common/cli.js';
 import { fmt } from '#src/common/fmt.js';
@@ -14,11 +15,13 @@ import { OperationError } from '../../error/operation-error.js';
 export interface AllowTargetAccessInput {
   target: InitTarget;
   bastion: Bastion;
+  tags: AwsTag[];
 }
 
 export async function allowTargetAccess({
   target,
   bastion,
+  tags,
 }: AllowTargetAccessInput): Promise<void> {
   if (!target.allowAccess) {
     cli.info(
@@ -35,6 +38,7 @@ export async function allowTargetAccess({
     cli.out(`${fmt.green('❯')} Configuring target access:`);
     await target.allowAccess({
       bastion,
+      tags,
       hooks: {
         onCreatingSecurityGroup: () =>
           subCli.progressStart('Creating access security group'),

--- a/src/cli/commands/init/create-bastion.ts
+++ b/src/cli/commands/init/create-bastion.ts
@@ -18,7 +18,7 @@ import { OperationError } from '../../error/operation-error.js';
 export interface CreateBastionInput {
   vpcId: string;
   subnetId: string;
-  tags?: AwsTag[];
+  tags: AwsTag[];
 }
 
 export async function createBastion({

--- a/src/cli/commands/init/create-bastion.ts
+++ b/src/cli/commands/init/create-bastion.ts
@@ -1,4 +1,5 @@
 import { AwsInstanceProfileNotFoundError } from '#src/aws/ec2/ec2-errors.js';
+import type { AwsTag } from '#src/aws/tags/types.js';
 import {
   BastionImageRetrievalError,
   BastionRoleCreationError,
@@ -17,11 +18,13 @@ import { OperationError } from '../../error/operation-error.js';
 export interface CreateBastionInput {
   vpcId: string;
   subnetId: string;
+  tags?: AwsTag[];
 }
 
 export async function createBastion({
   vpcId,
   subnetId,
+  tags,
 }: CreateBastionInput): Promise<Bastion> {
   const subCli = cli.createSubInstance({ indent: 2 });
 
@@ -30,6 +33,7 @@ export async function createBastion({
     const bastion = await bastionOps.createBastion({
       vpcId,
       subnetId,
+      tags,
       hooks: {
         onRetrievingImageId: () =>
           subCli.progressStart('Retrieving the latest EC2 AMI'),

--- a/src/cli/commands/init/init.ts
+++ b/src/cli/commands/init/init.ts
@@ -26,7 +26,11 @@ export async function handleInit(input: InitCommandInput): Promise<void> {
 
   const bastion =
     (await getBastion({ vpcId: targetVpcId })) ??
-    (await createBastion({ vpcId: targetVpcId, subnetId: bastionSubnet }));
+    (await createBastion({
+      vpcId: targetVpcId,
+      subnetId: bastionSubnet,
+      tags: [],
+    }));
 
   await allowTargetAccess({ target, bastion, tags: [] });
 }

--- a/src/cli/commands/init/init.ts
+++ b/src/cli/commands/init/init.ts
@@ -1,3 +1,5 @@
+import type { AwsTag } from '#src/aws/tags/types.js';
+
 import { allowTargetAccess } from './allow-target-access.js';
 import { assertTargetIsNotInitialized } from './assert-target-is-not-initiated.js';
 import { createBastion } from './create-bastion.js';
@@ -11,6 +13,7 @@ import type { DehydratedInitTargetInput } from './select-init-target.js';
 export interface InitCommandInput {
   target?: DehydratedInitTargetInput;
   bastionSubnet?: string;
+  tags: AwsTag[];
 }
 
 export async function handleInit(input: InitCommandInput): Promise<void> {
@@ -29,8 +32,8 @@ export async function handleInit(input: InitCommandInput): Promise<void> {
     (await createBastion({
       vpcId: targetVpcId,
       subnetId: bastionSubnet,
-      tags: [],
+      tags: input.tags,
     }));
 
-  await allowTargetAccess({ target, bastion, tags: [] });
+  await allowTargetAccess({ target, bastion, tags: input.tags });
 }

--- a/src/cli/commands/init/init.ts
+++ b/src/cli/commands/init/init.ts
@@ -28,5 +28,5 @@ export async function handleInit(input: InitCommandInput): Promise<void> {
     (await getBastion({ vpcId: targetVpcId })) ??
     (await createBastion({ vpcId: targetVpcId, subnetId: bastionSubnet }));
 
-  await allowTargetAccess({ target, bastion });
+  await allowTargetAccess({ target, bastion, tags: [] });
 }

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -53,6 +53,11 @@ void yargs(hideBin(process.argv))
           type: 'string',
           description: 'ID of the public VPC subnet for the bastion instance',
         })
+        .option('tag', {
+          type: 'array',
+          description:
+            'One or multiple tags to be added to all created resources',
+        })
         .option(...YARGS_AWS_CLIENT_OPTIONS.AWS_PROFILE)
         .option(...YARGS_AWS_CLIENT_OPTIONS.AWS_REGION)
         .check(
@@ -61,7 +66,7 @@ void yargs(hideBin(process.argv))
         .example([
           ['$0 init', 'Use interactive mode'],
           [
-            '$0 --rds-instance <id> --bastion-subnet <id>',
+            '$0 init --rds-instance <id> --bastion-subnet <id>',
             'Select target and bastion subnet automatically',
           ],
         ]),

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -54,9 +54,14 @@ void yargs(hideBin(process.argv))
           description: 'ID of the public VPC subnet for the bastion instance',
         })
         .option('tag', {
-          type: 'array',
+          type: 'string',
           description:
             'One or multiple tags to be added to all created resources',
+        })
+        .options('tags-file', {
+          type: 'string',
+          description:
+            'Path to a JSON file containing tags to be added to all created resources',
         })
         .option(...YARGS_AWS_CLIENT_OPTIONS.AWS_PROFILE)
         .option(...YARGS_AWS_CLIENT_OPTIONS.AWS_REGION)

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -56,12 +56,12 @@ void yargs(hideBin(process.argv))
         .option('tag', {
           type: 'string',
           description:
-            'One or multiple tags to be added to all created resources',
+            'Tag to be added to all created resources. Can be used multiple times',
         })
         .options('tags-file', {
           type: 'string',
           description:
-            'Path to a JSON file containing tags to be added to all created resources',
+            'Path to a JSON file containing tags to be added to all created resources. Can be used multiple times',
         })
         .option(...YARGS_AWS_CLIENT_OPTIONS.AWS_PROFILE)
         .option(...YARGS_AWS_CLIENT_OPTIONS.AWS_REGION)

--- a/src/cli/yargs/get-command-input.ts
+++ b/src/cli/yargs/get-command-input.ts
@@ -1,7 +1,6 @@
-import type { AwsTag } from '#src/aws/tags/types.js';
+import { getTagsFromOptions } from './tags/get-tags-from-options.js';
 
-import { OperationError } from '../error/operation-error.js';
-
+import type { TagOptions } from './tags/get-tags-from-options.js';
 import type { InitCommandInput } from '../commands/init/init.js';
 import type { ConnectCommandInput } from '../commands/connect/connect.js';
 
@@ -27,8 +26,7 @@ export type InitOptions = Partial<RdsInstanceOptions> &
   Partial<RdsClusterOptions> &
   Partial<CustomTargetVpcOptions> & {
     bastionSubnet?: string;
-    tags?: Array<string | number>;
-  };
+  } & TagOptions;
 
 export type ConnectOptions = Partial<RdsInstanceOptions> &
   Partial<RdsClusterOptions> &
@@ -58,7 +56,7 @@ export function getInitCommandInputFromOptions(
         }
       : undefined,
     bastionSubnet: options.bastionSubnet,
-    tags: parseTags(options.tags),
+    tags: getTagsFromOptions(options),
   };
 }
 
@@ -113,30 +111,4 @@ function isCustomTargetOptions(
 ): options is CustomTargetOptions;
 function isCustomTargetOptions(options: ConnectOptions | InitOptions): any {
   return 'customTargetVpc' in options;
-}
-
-function parseTags(tags: Array<string | number> | undefined): AwsTag[] {
-  if (tags === undefined || tags.length === 0) {
-    return [];
-  }
-
-  return tags.map(tag => parseTag(tag));
-}
-
-function parseTag(tag: string | number): AwsTag {
-  const parts = tag
-    .toString()
-    .split(/(?<!(?<!\\)\\)=/)
-    .map(part => part.replace(/\\=/g, '=').replace(/\\\\/g, '\\'));
-
-  if (parts.length !== 2) {
-    throw OperationError.fromErrorMessage({
-      operationName: 'Parsing tags',
-      message: `Each tag should be a key-value pair separated by an equal sign.`,
-    });
-  }
-
-  const [key, value] = parts as [string, string];
-
-  return { key, value };
 }

--- a/src/cli/yargs/tags/get-tag-from-option.ts
+++ b/src/cli/yargs/tags/get-tag-from-option.ts
@@ -1,0 +1,16 @@
+import type { AwsTag } from '#src/aws/tags/types.js';
+import { OperationError } from '#src/cli/error/operation-error.js';
+
+export function getTagFromOption(tagOption: string): AwsTag {
+  const parts = tagOption.split('=');
+
+  if (parts.length !== 2) {
+    throw OperationError.fromErrorMessage({
+      operationName: 'Parsing tags',
+      message: `Each tag should be a key-value pair separated by an equal sign.`,
+    });
+  }
+  const [key, value] = parts as [string, string];
+
+  return { key, value };
+}

--- a/src/cli/yargs/tags/get-tags-from-file.ts
+++ b/src/cli/yargs/tags/get-tags-from-file.ts
@@ -1,0 +1,40 @@
+import fs from 'node:fs';
+
+import { fromZodError } from 'zod-validation-error';
+
+import type { AwsTag } from '#src/aws/tags/types.js';
+import { OperationError } from '#src/cli/error/operation-error.js';
+
+import { TagsFileParser } from './tags-file-parser.js';
+
+export function getTagsFromFile(tagsFilePath: string): AwsTag[] {
+  const tagsFile = readTagsFile(tagsFilePath);
+
+  return parseTagsFile(tagsFile);
+}
+
+function readTagsFile(path: string): unknown {
+  try {
+    const content = fs.readFileSync(path);
+
+    return JSON.parse(content.toString());
+  } catch (error) {
+    throw OperationError.fromError({
+      error,
+      operationName: 'Reading tags file',
+    });
+  }
+}
+
+function parseTagsFile(tagsFile: unknown): AwsTag[] {
+  const result = TagsFileParser.safeParse(tagsFile);
+
+  if (!result.success) {
+    throw OperationError.fromErrorMessage({
+      operationName: 'Parsing tags file',
+      message: fromZodError(result.error).message,
+    });
+  }
+
+  return Object.entries(result.data).map(([key, value]) => ({ key, value }));
+}

--- a/src/cli/yargs/tags/get-tags-from-options.ts
+++ b/src/cli/yargs/tags/get-tags-from-options.ts
@@ -1,0 +1,28 @@
+import type { AwsTag } from '#src/aws/tags/types.js';
+import { uniqueBy } from '#src/common/data-structures.js';
+
+import { getTagFromOption } from './get-tag-from-option.js';
+import { getTagsFromFile } from './get-tags-from-file.js';
+
+export interface TagOptions {
+  tag?: string | string[];
+  tagsFile?: string | string[];
+}
+
+export function getTagsFromOptions(options: TagOptions): AwsTag[] {
+  const tagsFromFiles = toArray(options.tagsFile).flatMap(file =>
+    getTagsFromFile(file)
+  );
+  const tagsFromOptions = toArray(options.tag).map(tag =>
+    getTagFromOption(tag)
+  );
+
+  // Subsequent tag files override previous ones.
+  // Subsequent tag options override previous ones.
+  // Tag options always override tags from files.
+  return uniqueBy([...tagsFromFiles, ...tagsFromOptions], 'key');
+}
+
+function toArray(value: string | string[] | undefined): string[] {
+  return value === undefined ? [] : Array.isArray(value) ? value : [value];
+}

--- a/src/cli/yargs/tags/tags-file-parser.ts
+++ b/src/cli/yargs/tags/tags-file-parser.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const TagsFileParser = z.record(z.string(), z.string());
+
+export type TagsFile = z.infer<typeof TagsFileParser>;

--- a/src/common/data-structures.ts
+++ b/src/common/data-structures.ts
@@ -1,0 +1,13 @@
+export function indexBy<T>(array: T[], key: keyof T): Record<string, T> {
+  const result: Record<string, T> = {};
+
+  for (const item of array) {
+    result[item[key] as unknown as string] = item;
+  }
+
+  return result;
+}
+
+export function uniqueBy<T>(array: T[], key: keyof T): T[] {
+  return Object.values(indexBy(array, key));
+}

--- a/src/target/init-target.ts
+++ b/src/target/init-target.ts
@@ -1,3 +1,5 @@
+import type { AwsTag } from '#src/aws/tags/types.js';
+
 import { createSecurityGroup } from '../aws/ec2/create-security-group.js';
 import { getSecurityGroups } from '../aws/ec2/get-security-groups.js';
 import { generateShortId } from '../common/short-id.js';
@@ -20,6 +22,7 @@ interface InitTargetAllowAccessHooks {
 
 export interface InitTargetAllowAccessInput {
   bastion: Bastion;
+  tags: AwsTag[];
   hooks?: InitTargetAllowAccessHooks;
 }
 
@@ -42,10 +45,12 @@ export abstract class InitTargetBase implements InitTarget {
 
   async allowAccess({
     bastion,
+    tags,
     hooks,
   }: InitTargetAllowAccessInput): Promise<void> {
     const accessSecurityGroup = await this.createAccessSecurityGroup(
       bastion,
+      tags,
       hooks
     );
 
@@ -71,6 +76,7 @@ export abstract class InitTargetBase implements InitTarget {
 
   private async createAccessSecurityGroup(
     bastion: Bastion,
+    tags: AwsTag[],
     hooks?: InitTargetAllowAccessHooks
   ): Promise<AwsSecurityGroup> {
     try {
@@ -93,6 +99,7 @@ export abstract class InitTargetBase implements InitTarget {
             },
           },
         ],
+        tags,
       });
       hooks?.onSecurityGroupCreated?.(accessSecurityGroup.id);
       return accessSecurityGroup;


### PR DESCRIPTION
## Proposed Changes

This PR makes the `basti init` command tag all the created resources if instructed with any of the following CLI arguments:
1. `--tag` - specifies a single tag as a name/value pair separated by an equal sign. Can be used multiple times
2. `--tags-file` - specifies a JSON file that can contain multiple tags as key-value pairs of the root object.

If the `--tag` option is used multiple times with the same tag name, the latter usage will override the previous ones. The same applies to `--tags-file`. Tags specified with the `--tag` option will always override tags from files.

An example of a tags file:

```json
{
  "any characters can be used here ++-@====": "value",
  "another-tag-here": "tag-value"
}
```

Example of the command usage:

```sh
basti init --tags-file test-tags.json --tags-file test-tags-2.json --tag "one more tag=value here"
```

## Related Issue

#50

## Checklist

- [x] All the tests and checks passed (`npm run test`).
- [x] I have added necessary documentation and/or updated existing documentation. **Documentation will be added in a separate PR** <!-- check if not applicable --> (
- [x] I have added or modified tests to cover the changes. <!-- check if not applicable -->

