### PR TITLE
feat: resource tags in interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@
   - [Use target on _localhost_](#use-target-on-localhost)
   - [Cleanup (optional)](#cleanup-optional)
 - [Custom connection targets](#custom-connection-targets)
+- [Advanced initialization options](#advanced-initialization-options)
+  - [Resource tags](#resource-tags)
 - [Basti in CI/CD pipelines](#basti-in-cicd-pipelines)
   - [Automatic mode](#automatic-mode)
 - [Basti configuration file](#basti-configuration-file)
@@ -136,6 +138,31 @@ Basti provides first class support for RDS instances and Aurora clusters. Howeve
 To connect to a custom target, select the `Custom` option when prompted for a target to initialize or connect to. You will be prompted for the target's VPC, IP address and port.
 
 > 🤝 Feel free to open an issue or a pull request if you want to extend the list of natively supported targets
+
+## Advanced initialization options
+
+The `basti init` command has a number of advanced options that can be used to customize the bastion instance and other resources created by Basti.
+
+### Resource tags
+
+You can specify tags to be applied to the bastion instance and other resources created by Basti. This can be done in three ways:
+
+1. By entering the tags in the advanced options section of the interactive mode.
+2. By passing the `--tag` option. This option accepts tag name and value separated by an equal sign. For example, `--tag Project=my-project` This option can be used multiple times to specify multiple tags.
+3. By passing the `--tags-file` option. This option accepts a path to a JSON file with tags. The option can be used multiple times to specify multiple files.
+
+Example of a tags file:
+
+```json
+{
+  "Project": "my-project",
+  "Environment": "production"
+}
+```
+
+Tags with the same name will be overwritten in the order they are specified. Tags specified with the `--tag` option will always overwrite tags specified in the tags file.
+
+> 💡 If your tags contain special characters, it might be easier to use interactive mode or the `--tags-file` command than escaping the characters in the `--tag` option.
 
 ## Basti in CI/CD pipelines
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,25 @@
 {
   "name": "basti",
-  "version": "1.2.0",
+  "version": "1.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "basti",
-      "version": "1.2.0",
-      "license": "ISC",
+      "version": "1.3.4",
+      "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-ec2": "3.231.0",
         "@aws-sdk/client-iam": "3.231.0",
         "@aws-sdk/client-rds": "3.231.0",
         "@aws-sdk/client-ssm": "3.231.0",
         "chalk": "5.0.1",
-        "cosmiconfig": "^8.1.3",
+        "cosmiconfig": "8.1.3",
         "inquirer": "9.0.0",
         "ora": "6.1.2",
-        "yargs": "^17.7.2",
-        "zod": "^3.18.0",
-        "zod-validation-error": "^1.3.0"
+        "yargs": "17.7.2",
+        "zod": "3.18.0",
+        "zod-validation-error": "1.3.0"
       },
       "bin": {
         "basti": "bin/run.js"

--- a/src/aws/ec2/create-ec2-instance.ts
+++ b/src/aws/ec2/create-ec2-instance.ts
@@ -90,7 +90,7 @@ export async function createEc2Instance({
           },
 
           TagSpecifications: [
-            toTagSpecification('instance', [...instanceTags, ...tagsWithName]),
+            toTagSpecification('instance', [...tagsWithName, ...instanceTags]),
             toTagSpecification('volume', tagsWithName),
             toTagSpecification('network-interface', tagsWithName),
           ],

--- a/src/cli/commands/init/advanced-input/select-advanced-input.ts
+++ b/src/cli/commands/init/advanced-input/select-advanced-input.ts
@@ -1,0 +1,32 @@
+import { cli } from '#src/common/cli.js';
+
+import {
+  isRequiredInputComplete,
+  type InitCommandAdvancedInput,
+  type InitCommandInput,
+  isAdvancedInputComplete,
+} from '../init-command-input.js';
+
+import { selectTags } from './select-tags.js';
+
+export async function selectAdvancedInput(
+  input: InitCommandInput
+): Promise<InitCommandAdvancedInput> {
+  if (isRequiredInputComplete(input) || isAdvancedInputComplete(input)) {
+    return input;
+  }
+
+  const { proceedToAdvancedOptions } = await cli.prompt({
+    type: 'confirm',
+    name: 'proceedToAdvancedOptions',
+    message: 'Proceed to advanced options?',
+    default: false,
+  });
+  if (!(proceedToAdvancedOptions as boolean)) {
+    return input;
+  }
+
+  return {
+    tags: await selectTags(input.tags),
+  };
+}

--- a/src/cli/commands/init/advanced-input/select-advanced-input.ts
+++ b/src/cli/commands/init/advanced-input/select-advanced-input.ts
@@ -12,6 +12,8 @@ import { selectTags } from './select-tags.js';
 export async function selectAdvancedInput(
   input: InitCommandInput
 ): Promise<InitCommandAdvancedInput> {
+  // If the required input is complete, Basti must skip any other interactive
+  // input and proceed to execution immediately.
   if (isRequiredInputComplete(input) || isAdvancedInputComplete(input)) {
     return input;
   }

--- a/src/cli/commands/init/advanced-input/select-tags.ts
+++ b/src/cli/commands/init/advanced-input/select-tags.ts
@@ -1,0 +1,39 @@
+import { cli } from '#src/common/cli.js';
+import { uniqueBy } from '#src/common/data-structures.js';
+import { fmt } from '#src/common/fmt.js';
+
+import type { InitCommandAdvancedInput } from '../init-command-input.js';
+
+type TagsInput = InitCommandAdvancedInput['tags'];
+
+export async function selectTags(tagsInput: TagsInput): Promise<TagsInput> {
+  if (tagsInput.length > 0) {
+    return tagsInput;
+  }
+
+  cli.out(`${fmt.green('❯')} Enter tags to be added to all created resources`);
+
+  const subCli = cli.createSubInstance({ indent: 2 });
+
+  const tags: TagsInput = [];
+  while (true) {
+    const { tagKey } = await subCli.prompt({
+      type: 'input',
+      name: 'tagKey',
+      message: 'Tag key (leave empty to proceed)',
+    });
+    if (typeof tagKey !== 'string' || tagKey.length === 0) {
+      break;
+    }
+
+    const { tagValue } = await subCli.prompt({
+      type: 'input',
+      name: 'tagValue',
+      message: `Tag value`,
+    });
+
+    tags.push({ key: tagKey, value: tagValue });
+  }
+
+  return uniqueBy(tags, 'key');
+}

--- a/src/cli/commands/init/init-command-input.ts
+++ b/src/cli/commands/init/init-command-input.ts
@@ -1,0 +1,23 @@
+import type { AwsTag } from '#src/aws/tags/types.js';
+
+import type { DehydratedInitTargetInput } from './select-init-target.js';
+
+export interface InitCommandRequiredInput {
+  target?: DehydratedInitTargetInput;
+  bastionSubnet?: string;
+}
+
+export interface InitCommandAdvancedInput {
+  tags: AwsTag[];
+}
+
+export type InitCommandInput = InitCommandRequiredInput &
+  InitCommandAdvancedInput;
+
+export function isRequiredInputComplete(input: InitCommandInput): boolean {
+  return input.target !== undefined && input.bastionSubnet !== undefined;
+}
+
+export function isAdvancedInputComplete(input: InitCommandInput): boolean {
+  return input.tags.length > 0;
+}

--- a/src/cli/commands/init/init.ts
+++ b/src/cli/commands/init/init.ts
@@ -1,5 +1,3 @@
-import type { AwsTag } from '#src/aws/tags/types.js';
-
 import { allowTargetAccess } from './allow-target-access.js';
 import { assertTargetIsNotInitialized } from './assert-target-is-not-initiated.js';
 import { createBastion } from './create-bastion.js';
@@ -7,14 +5,9 @@ import { getBastion } from './get-bastion.js';
 import { getTargetVpc } from './get-target-vpc.js';
 import { selectBastionSubnetId } from './select-bastion-subnet.js';
 import { selectInitTarget } from './select-init-target.js';
+import { selectAdvancedInput } from './advanced-input/select-advanced-input.js';
 
-import type { DehydratedInitTargetInput } from './select-init-target.js';
-
-export interface InitCommandInput {
-  target?: DehydratedInitTargetInput;
-  bastionSubnet?: string;
-  tags: AwsTag[];
-}
+import type { InitCommandInput } from './init-command-input.js';
 
 export async function handleInit(input: InitCommandInput): Promise<void> {
   const target = await selectInitTarget(input.target);
@@ -25,6 +18,8 @@ export async function handleInit(input: InitCommandInput): Promise<void> {
     bastionSubnetInput: input.bastionSubnet,
   });
 
+  const advancedInput = await selectAdvancedInput(input);
+
   await assertTargetIsNotInitialized({ target });
 
   const bastion =
@@ -32,8 +27,8 @@ export async function handleInit(input: InitCommandInput): Promise<void> {
     (await createBastion({
       vpcId: targetVpcId,
       subnetId: bastionSubnet,
-      tags: input.tags,
+      tags: advancedInput.tags,
     }));
 
-  await allowTargetAccess({ target, bastion, tags: input.tags });
+  await allowTargetAccess({ target, bastion, tags: advancedInput.tags });
 }

--- a/src/cli/yargs/get-command-input.ts
+++ b/src/cli/yargs/get-command-input.ts
@@ -1,7 +1,7 @@
 import { getTagsFromOptions } from './tags/get-tags-from-options.js';
 
 import type { TagOptions } from './tags/get-tags-from-options.js';
-import type { InitCommandInput } from '../commands/init/init.js';
+import type { InitCommandInput } from '../commands/init/init-command-input.js';
 import type { ConnectCommandInput } from '../commands/connect/connect.js';
 
 export interface RdsInstanceOptions {

--- a/src/common/data-structures.ts
+++ b/src/common/data-structures.ts
@@ -11,3 +11,7 @@ export function indexBy<T>(array: T[], key: keyof T): Record<string, T> {
 export function uniqueBy<T>(array: T[], key: keyof T): T[] {
   return Object.values(indexBy(array, key));
 }
+
+export function toArray<T>(value: T | T[]): T[] {
+  return Array.isArray(value) ? value : [value];
+}

--- a/src/common/fmt.ts
+++ b/src/common/fmt.ts
@@ -1,6 +1,10 @@
 import chalk from 'chalk';
 
 export class Fmt {
+  reset(message: string): string {
+    return chalk.reset(message);
+  }
+
   value(message: string): string {
     return chalk.cyan(message);
   }


### PR DESCRIPTION
## Proposed Changes

This PR introduces the new Advanced Options section in the interactive mode. User will be prompted for advanced options only if not all the required options are specified. This will maintain the existing automatic mode behavior - if all the required options are provided via CLI arguments, Basti must immediately proceed to execution.

## Related Issue

[closes #50]

## Checklist

- [x] All the tests and checks passed (`npm run test`).
- [x] I have added necessary documentation and/or updated existing documentation. <!-- check if not applicable -->
- [x] I have added or modified tests to cover the changes. <!-- check if not applicable -->

