### PR TITLE
feat: configurable instance type

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 - [Custom connection targets](#custom-connection-targets)
 - [Advanced initialization options](#advanced-initialization-options)
   - [Resource tags](#resource-tags)
+  - [Bastion instance type](#bastion-instance-type)
 - [Basti in CI/CD pipelines](#basti-in-cicd-pipelines)
   - [Automatic mode](#automatic-mode)
 - [Basti configuration file](#basti-configuration-file)
@@ -163,6 +164,10 @@ Example of a tags file:
 Tags with the same name will be overwritten in the order they are specified. Tags specified with the `--tag` option will always overwrite tags specified in the tags file.
 
 > 💡 If your tags contain special characters, it might be easier to use interactive mode or the `--tags-file` command than escaping the characters in the `--tag` option.
+
+### Bastion instance type
+
+You can specify the EC2 instance type to be used for the bastion instance using the `--bastion-instance-type` option or by entering it in the advanced options section of the interactive mode. The default instance type is `t2.micro`, but it's subject to change in the future.
 
 ## Basti in CI/CD pipelines
 

--- a/src/aws/ec2/create-security-group.ts
+++ b/src/aws/ec2/create-security-group.ts
@@ -72,7 +72,10 @@ export async function createSecurityGroup({
       new AuthorizeSecurityGroupIngressCommand({
         GroupId,
         IpPermissions: ingressRules.map(rule => toIpPermission(rule)),
-        TagSpecifications: [toTagSpecification('security-group-rule', tags)],
+        TagSpecifications:
+          tags.length > 0
+            ? [toTagSpecification('security-group-rule', tags)]
+            : undefined,
       })
     );
   }

--- a/src/aws/ec2/upsert-tags.ts
+++ b/src/aws/ec2/upsert-tags.ts
@@ -13,6 +13,10 @@ export async function upsertTags({
   resourceIds,
   tags,
 }: UpsertTagsInput): Promise<void> {
+  if (resourceIds.length === 0 || tags.length === 0) {
+    return;
+  }
+
   await ec2Client.send(
     new CreateTagsCommand({
       Resources: resourceIds,

--- a/src/bastion/bastion.ts
+++ b/src/bastion/bastion.ts
@@ -25,3 +25,5 @@ export const BASTION_INSTANCE_ID_TAG_NAME = 'basti:id';
 export const BASTION_INSTANCE_IN_USE_TAG_NAME = 'basti:in-use';
 export const BASTION_INSTANCE_UPDATING_TAG_NAME = 'basti:updating';
 export const BASTION_INSTANCE_UPDATED_TAG_NAME = 'basti:updated';
+
+export const BASTION_INSTANCE_DEFAULT_INSTANCE_TYPE = 't2.micro';

--- a/src/bastion/create-bastion.ts
+++ b/src/bastion/create-bastion.ts
@@ -22,6 +22,7 @@ import {
   BASTION_INSTANCE_NAME_PREFIX,
   BASTION_INSTANCE_PROFILE_PATH,
   BASTION_INSTANCE_SECURITY_GROUP_NAME_PREFIX,
+  BASTION_INSTANCE_DEFAULT_INSTANCE_TYPE,
 } from './bastion.js';
 
 import type { Bastion } from './bastion.js';
@@ -45,6 +46,7 @@ interface CreateBastionHooks {
 export interface CreateBastionInput {
   vpcId: string;
   subnetId: string;
+  instanceType: string | undefined;
   tags: AwsTag[];
   hooks?: CreateBastionHooks;
 }
@@ -52,6 +54,7 @@ export interface CreateBastionInput {
 export async function createBastion({
   vpcId,
   subnetId,
+  instanceType,
   tags,
   hooks,
 }: CreateBastionInput): Promise<Bastion> {
@@ -74,6 +77,7 @@ export async function createBastion({
     bastionRole,
     subnetId,
     bastionSecurityGroup,
+    instanceType,
     tags,
     hooks
   );
@@ -184,6 +188,7 @@ async function createBastionInstance(
   bastionRole: AwsRole,
   subnetId: string,
   bastionSecurityGroup: AwsSecurityGroup,
+  instanceType: string | undefined,
   tags: AwsTag[],
   hooks?: CreateBastionHooks
 ): Promise<AwsEc2Instance> {
@@ -192,7 +197,7 @@ async function createBastionInstance(
     const bastionInstance = await createEc2Instance({
       name: `${BASTION_INSTANCE_NAME_PREFIX}-${bastionId}`,
       imageId: bastionImageId,
-      instanceType: 't2.micro',
+      instanceType: instanceType ?? BASTION_INSTANCE_DEFAULT_INSTANCE_TYPE,
       roleNames: [bastionRole.name],
       profilePath: BASTION_INSTANCE_PROFILE_PATH,
       subnetId,

--- a/src/cli/commands/init/advanced-input/select-advanced-input.ts
+++ b/src/cli/commands/init/advanced-input/select-advanced-input.ts
@@ -29,8 +29,11 @@ export async function selectAdvancedInput(
     return input;
   }
 
+  const instanceType = await selectInstanceType(input.instanceType);
+  const tags = await selectTags(input.tags);
+
   return {
-    tags: await selectTags(input.tags),
-    instanceType: await selectInstanceType(input.instanceType),
+    instanceType,
+    tags,
   };
 }

--- a/src/cli/commands/init/advanced-input/select-advanced-input.ts
+++ b/src/cli/commands/init/advanced-input/select-advanced-input.ts
@@ -7,6 +7,7 @@ import {
   isAdvancedInputComplete,
 } from '../init-command-input.js';
 
+import { selectInstanceType } from './select-instance-type.js';
 import { selectTags } from './select-tags.js';
 
 export async function selectAdvancedInput(
@@ -30,5 +31,6 @@ export async function selectAdvancedInput(
 
   return {
     tags: await selectTags(input.tags),
+    instanceType: await selectInstanceType(input.instanceType),
   };
 }

--- a/src/cli/commands/init/advanced-input/select-instance-type.ts
+++ b/src/cli/commands/init/advanced-input/select-instance-type.ts
@@ -11,7 +11,7 @@ export async function selectInstanceType(
   const { instanceType } = await cli.prompt({
     type: 'input',
     name: 'instanceType',
-    message: 'EC2 instance type',
+    message: 'EC2 instance type for the bastion',
     default: BASTION_INSTANCE_DEFAULT_INSTANCE_TYPE,
   });
 

--- a/src/cli/commands/init/advanced-input/select-instance-type.ts
+++ b/src/cli/commands/init/advanced-input/select-instance-type.ts
@@ -1,0 +1,19 @@
+import { BASTION_INSTANCE_DEFAULT_INSTANCE_TYPE } from '#src/bastion/bastion.js';
+import { cli } from '#src/common/cli.js';
+
+export async function selectInstanceType(
+  instanceTypeInput: string | undefined
+): Promise<string> {
+  if (instanceTypeInput !== undefined) {
+    return instanceTypeInput;
+  }
+
+  const { instanceType } = await cli.prompt({
+    type: 'input',
+    name: 'instanceType',
+    message: 'EC2 instance type',
+    default: BASTION_INSTANCE_DEFAULT_INSTANCE_TYPE,
+  });
+
+  return instanceType;
+}

--- a/src/cli/commands/init/create-bastion.ts
+++ b/src/cli/commands/init/create-bastion.ts
@@ -18,12 +18,14 @@ import { OperationError } from '../../error/operation-error.js';
 export interface CreateBastionInput {
   vpcId: string;
   subnetId: string;
+  instanceType: string | undefined;
   tags: AwsTag[];
 }
 
 export async function createBastion({
   vpcId,
   subnetId,
+  instanceType,
   tags,
 }: CreateBastionInput): Promise<Bastion> {
   const subCli = cli.createSubInstance({ indent: 2 });
@@ -33,6 +35,7 @@ export async function createBastion({
     const bastion = await bastionOps.createBastion({
       vpcId,
       subnetId,
+      instanceType,
       tags,
       hooks: {
         onRetrievingImageId: () =>

--- a/src/cli/commands/init/init-command-input.ts
+++ b/src/cli/commands/init/init-command-input.ts
@@ -9,6 +9,7 @@ export interface InitCommandRequiredInput {
 
 export interface InitCommandAdvancedInput {
   tags: AwsTag[];
+  instanceType?: string;
 }
 
 export type InitCommandInput = InitCommandRequiredInput &
@@ -19,5 +20,5 @@ export function isRequiredInputComplete(input: InitCommandInput): boolean {
 }
 
 export function isAdvancedInputComplete(input: InitCommandInput): boolean {
-  return input.tags.length > 0;
+  return input.tags.length > 0 && input.instanceType !== undefined;
 }

--- a/src/cli/commands/init/init.ts
+++ b/src/cli/commands/init/init.ts
@@ -27,6 +27,7 @@ export async function handleInit(input: InitCommandInput): Promise<void> {
     (await createBastion({
       vpcId: targetVpcId,
       subnetId: bastionSubnet,
+      instanceType: advancedInput.instanceType,
       tags: advancedInput.tags,
     }));
 

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -53,6 +53,10 @@ void yargs(hideBin(process.argv))
           type: 'string',
           description: 'ID of the public VPC subnet for the bastion instance',
         })
+        .option('bastion-instance-type', {
+          type: 'string',
+          description: 'EC2 instance type for the bastion instance',
+        })
         .option('tag', {
           type: 'string',
           description:

--- a/src/cli/yargs/get-command-input.ts
+++ b/src/cli/yargs/get-command-input.ts
@@ -26,6 +26,7 @@ export type InitOptions = Partial<RdsInstanceOptions> &
   Partial<RdsClusterOptions> &
   Partial<CustomTargetVpcOptions> & {
     bastionSubnet?: string;
+    bastionInstanceType?: string;
   } & TagOptions;
 
 export type ConnectOptions = Partial<RdsInstanceOptions> &
@@ -57,6 +58,7 @@ export function getInitCommandInputFromOptions(
       : undefined,
     bastionSubnet: options.bastionSubnet,
     tags: getTagsFromOptions(options),
+    instanceType: options.bastionInstanceType,
   };
 }
 


### PR DESCRIPTION
## Proposed Changes

This PR adds ability to configure the EC2 instance type used for the bastion instance using the `--bastion-instance-type` CLI option or the advanced option in the interactive mode.

## Related Issue

#51 

## Checklist

- [x] All the tests and checks passed (`npm run test`).
- [x] I have added necessary documentation and/or updated existing documentation. <!-- check if not applicable -->
- [x] I have added or modified tests to cover the changes. <!-- check if not applicable -->

