### PR TITLE
fix(basti-cdk): use correct (global) port forwarding document arn

### DIFF
--- a/packages/basti-cdk/src/__test__/basti-instance.test.ts
+++ b/packages/basti-cdk/src/__test__/basti-instance.test.ts
@@ -269,18 +269,7 @@ describe('BastiInstanceTest', () => {
                   ],
                 ],
               },
-              {
-                'Fn::Join': [
-                  '',
-                  [
-                    'arn:aws:ssm:',
-                    { Ref: 'AWS::Region' },
-                    ':',
-                    { Ref: 'AWS::AccountId' },
-                    ':document/AWS-StartPortForwardingSessionToRemoteHost',
-                  ],
-                ],
-              },
+              'arn:aws:ssm:*:*:document/AWS-StartPortForwardingSessionToRemoteHost',
             ],
             Condition: {
               BoolIfExists: {

--- a/packages/basti-cdk/src/basti-instance.ts
+++ b/packages/basti-cdk/src/basti-instance.ts
@@ -206,7 +206,10 @@ export class BastiInstance extends Construct implements IBastiInstance {
   public grantBastiCliConnect(grantee: aws_iam.IGrantable): void {
     const account = Stack.of(this).account;
     const region = Stack.of(this).region;
+
     const instanceArn = `arn:aws:ec2:${region}:${account}:instance/${this.instance.instanceId}`;
+    const documentArn = `arn:aws:ssm:*:*:document/AWS-StartPortForwardingSessionToRemoteHost`;
+
     grantee.grantPrincipal.addToPrincipalPolicy(
       new aws_iam.PolicyStatement({
         actions: ['ec2:DescribeInstances'],
@@ -220,7 +223,6 @@ export class BastiInstance extends Construct implements IBastiInstance {
       })
     );
 
-    const documentArn = `arn:aws:ssm:${region}:${account}:document/AWS-StartPortForwardingSessionToRemoteHost`;
     grantee.grantPrincipal.addToPrincipalPolicy(
       new aws_iam.PolicyStatement({
         actions: ['ssm:StartSession'],


### PR DESCRIPTION
## Proposed Changes

This PR fixes the problem with using the permissions granted with the `BastionInstnace#grantBastiCliConnect` method. When the account ID is specified for the document ARN, IAM produces the following error:

```sh
An error occurred (AccessDeniedException) when calling the StartSession operation: User: arn:aws:sts::507082836245:assumed-role/cdk-test-basti-instance-grant-connect/BohdanMac is not authorized to perform: ssm:StartSession on resource: arn:aws:ssm:us-east-1::document/AWS-StartPortForwardingSessionToRemoteHost because no identity-based policy allows the ssm:StartSession action
```

## Related Issues/PRs

#48 

## Checklist

- [x] I cleaned up my code.
- [x] All the tests and checks passed (`npm run test`).
- [x] I have added necessary documentation and/or updated existing documentation. <!-- check if not applicable -->
- [x] I have added or modified tests to cover the changes. <!-- check if not applicable -->