### PR TITLE
fix(basti): remove redundant instance IAM policy

### DIFF
--- a/packages/basti/src/bastion/create-bastion-role.ts
+++ b/packages/basti/src/bastion/create-bastion-role.ts
@@ -63,11 +63,6 @@ function getSessionManagerAccessPolicy(): string {
         ],
         Resource: '*',
       },
-      {
-        Effect: 'Allow',
-        Action: ['s3:GetEncryptionConfiguration'],
-        Resource: '*',
-      },
     ],
   });
 }


### PR DESCRIPTION
## Proposed Changes

This PR removes the `s3:GetEncryptionConfiguration` action from the bastion instance policy as it is redundant.

## Related Issues/PRs

#52 

## Checklist

- [x] I cleaned up my code.
- [x] All the tests and checks passed (`npm run test`).
- [x] I have added necessary documentation and/or updated existing documentation. <!-- check if not applicable -->
- [x] I have added or modified tests to cover the changes. <!-- check if not applicable -->