### PR TITLE
fix(basti): use execFileSync instead of execSync in scripts

### DIFF
--- a/packages/basti/scripts/build-deps.ts
+++ b/packages/basti/scripts/build-deps.ts
@@ -66,18 +66,43 @@ function createSessionManagerDependencyBuilder(): DepBuilder {
     const repoDir = path.join(TMP_DIR, 'session-manager-plugin');
     if (!isBuilt) {
       console.log(`Cloning Session Manager ${version}...`);
-      cp.execSync(
-        `git clone --depth 1 --branch ${version} https://github.com/aws/session-manager-plugin.git ${repoDir}`,
+      cp.execFileSync(
+        'git',
+        [
+          'clone',
+          '--depth',
+          '1',
+          '--branch',
+          version,
+          'https://github.com/aws/session-manager-plugin.git',
+          repoDir,
+        ],
         {
           stdio: 'inherit',
         }
       );
       console.log('Building Session Manager...');
-      cp.execSync(`docker build -t session-manager-plugin-image ${repoDir}`, {
-        stdio: 'inherit',
-      });
-      cp.execSync(
-        `docker run -it --rm --name session-manager-plugin-build -v ${repoDir}:/session-manager-plugin session-manager-plugin-image make release`,
+      cp.execFileSync(
+        'docker',
+        ['build', '-t', 'session-manager-plugin-image', repoDir],
+        {
+          stdio: 'inherit',
+        }
+      );
+      cp.execFileSync(
+        'docker',
+        [
+          'run',
+          '-it',
+          '--rm',
+          '--name',
+          'session-manager-plugin-build',
+          '-v',
+          `${repoDir}:/session-manager-plugin`,
+          'session-manager-plugin-image',
+          'make',
+          'release',
+        ],
         {
           stdio: 'inherit',
         }

--- a/packages/basti/scripts/check-deps.ts
+++ b/packages/basti/scripts/check-deps.ts
@@ -27,9 +27,13 @@ function getVersionInfo(
   version: string
 ): Record<string, unknown> | undefined {
   try {
-    const versionInfoBuf = cp.execSync(`npm view --json ${dep}@${version}`, {
-      stdio: 'pipe',
-    });
+    const versionInfoBuf = cp.execFileSync(
+      'npm',
+      ['view', '--json', `${dep}@${version}`],
+      {
+        stdio: 'pipe',
+      }
+    );
 
     const versionInfoStr = versionInfoBuf?.toString();
 

--- a/packages/basti/scripts/publish-deps.ts
+++ b/packages/basti/scripts/publish-deps.ts
@@ -9,7 +9,7 @@ const deps = fs.readdirSync(DEPS_DIR);
 for (const dep of deps) {
   console.log(`Publishing ${dep}...`);
 
-  cp.execSync('npm publish', {
+  cp.execFileSync('npm', ['publish'], {
     cwd: path.join(DEPS_DIR, dep),
     stdio: 'inherit',
   });


### PR DESCRIPTION
## Proposed Changes

This PR replaces `execSync` usages with `execFileSync` according to a CodeQL alert:

> Dynamically constructing a shell command with values from the local environment, such as file paths, may inadvertently change the meaning of the shell command. Such changes can occur when an environment value contains characters that the shell interprets in a special way, for instance quotes and spaces. This can result in the shell command misbehaving, or even allowing a malicious user to execute arbitrary commands on the system.
> 
> Recommendation
> If possible, use hard-coded string literals to specify the shell command to run, and provide the dynamic arguments to the shell command separately to avoid interpretation by the shell.
> 
> Alternatively, if the shell command must be constructed dynamically, then add code to ensure that special characters in environment values do not alter the shell command unexpectedly.
> 
> Example
> The following example shows a dynamically constructed shell command that recursively removes a temporary directory that is located next to the currently executing JavaScript file. Such utilities are often found in custom build scripts.
> 
> var cp = require("child_process"),
>   path = require("path");
> function cleanupTemp() {
>   let cmd = "rm -rf " + path.join(__dirname, "temp");
>   cp.execSync(cmd); // BAD
> }
> The shell command will, however, fail to work as intended if the absolute path of the script's directory contains spaces. In that case, the shell command will interpret the absolute path as multiple paths, instead of a single path.
> 
> For instance, if the absolute path of the temporary directory is /home/username/important project/temp, then the shell command will recursively delete /home/username/important and project/temp, where the latter path gets resolved relative to the working directory of the JavaScript process.
> 
> Even worse, although less likely, a malicious user could provide the path /home/username/; cat /etc/passwd #/important project/temp in order to execute the command cat /etc/passwd.
> 
> To avoid such potentially catastrophic behaviors, provide the directory as an argument that does not get interpreted by a shell:
> 
> var cp = require("child_process"),
>   path = require("path");
> function cleanupTemp() {
>   let cmd = "rm",
>     args = ["-rf", path.join(__dirname, "temp")];
>   cp.execFileSync(cmd, args); // GOOD
> }
> References
> OWASP: [Command Injection](https://www.owasp.org/index.php/Command_Injection).
> Common Weakness Enumeration: [CWE-78](https://cwe.mitre.org/data/definitions/78.html).
> Common Weakness Enumeration: [CWE-88](https://cwe.mitre.org/data/definitions/88.html).

## Related Issues/PRs

N/A

## Checklist

- [x] I cleaned up my code.
- [x] All the tests and checks passed (`npm run test`).
- [x] I have added necessary documentation and/or updated existing documentation. <!-- check if not applicable -->
- [x] I have added or modified tests to cover the changes. <!-- check if not applicable -->