### PR TITLE
Add support for parsing config file for basti init

### DIFF
--- a/packages/basti/src/cli/commands/init/init.ts
+++ b/packages/basti/src/cli/commands/init/init.ts
@@ -7,7 +7,7 @@ import { selectBastionSubnetId } from './select-bastion-subnet.js';
 import { selectInitTarget } from './select-init-target.js';
 import { selectAdvancedInput } from './advanced-input/select-advanced-input.js';
 
-import type { InitCommandInput } from './init-command-input.js';
+import type { InitCommandInput, InitCommandRequiredInput } from './init-command-input.js';
 
 export async function handleInit(input: InitCommandInput): Promise<void> {
   const target = await selectInitTarget(input.target);

--- a/packages/basti/src/cli/commands/init/select-init-target.ts
+++ b/packages/basti/src/cli/commands/init/select-init-target.ts
@@ -11,10 +11,14 @@ import { handleOperation } from '../common/handle-operation.js';
 import { hydrateAwsTarget } from '../common/hydrate-aws-target.js';
 
 import type { DehydratedAwsTargetInput } from '../common/hydrate-aws-target.js';
+import { AwsClientConfiguration } from '#src/aws/common/aws-client.js';
 
 export type DehydratedInitTargetInput =
   | DehydratedAwsTargetInput
-  | { customTargetVpcId: string };
+  | { customTargetVpcId: string }
+   & {
+    awsClientConfig?: AwsClientConfiguration;
+  };
 
 export async function selectInitTarget(
   dehydratedInput?: DehydratedInitTargetInput

--- a/packages/basti/src/cli/config/config-parser.ts
+++ b/packages/basti/src/cli/config/config-parser.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 const TargetConfigBaseParser = z.object({
   awsProfile: z.string().optional(),
   awsRegion: z.string().optional(),
+  bastionSubnet: z.string().optional()
 });
 export type TargetConfigBase = z.infer<typeof TargetConfigBaseParser>;
 

--- a/packages/basti/src/cli/config/get-init-input.ts
+++ b/packages/basti/src/cli/config/get-init-input.ts
@@ -1,0 +1,102 @@
+import { InitCommandInput, InitCommandRequiredInput } from '../commands/init/init-command-input.js';
+import { OperationError } from '../error/operation-error.js';
+import { InitOptions } from '../yargs/get-command-input.js';
+import { getTagsFromOptions } from '../yargs/tags/get-tags-from-options.js';
+
+import {
+  isRdsClusterTargetConfig,
+  isRdsInstanceTargetConfig,
+  isElasticacheRedisClusterTargetConfig,
+  isElasticacheRedisNodeTargetConfig,
+  isElasticacheMemcachedClusterTargetConfig,
+  isElasticacheMemcachedNodeTargetConfig,
+} from './config-parser.js';
+
+
+import type { Config } from './config-parser.js';
+
+export function getInitCommandInputFromConfig(
+  config: Config | undefined,
+  target: string,
+  options: InitOptions
+): InitCommandInput {
+  if (!config) {
+    throw OperationError.fromErrorMessage({
+      operationName: 'Resolving target from configuration file',
+      message: 'No configuration file found',
+    });
+  }
+
+  const targetConfig = config.targets?.[target];
+
+  if (!targetConfig) {
+    throw OperationError.fromErrorMessage({
+      operationName: 'Resolving initialization from configuration file',
+      message: `No target with name "${target}" found in configuration file`,
+    });
+  }
+  console.log(targetConfig)
+  
+  const initTarget =
+    typeof targetConfig === 'object'
+      ? targetConfig
+      : config.targets?.[target];
+
+  if (!initTarget) {
+    throw OperationError.fromErrorMessage({
+      operationName: 'Resolving target from configuration file',
+      message: `No target with name "${
+        target as string
+      }" found in configuration file`,
+    });
+  }
+
+  const awsClientConfig =
+    initTarget.awsProfile !== undefined ||
+    initTarget.awsRegion !== undefined
+      ? {
+          profile: initTarget.awsProfile,
+          region: initTarget.awsRegion,
+        }
+      : undefined;
+
+  return {
+    target: isRdsInstanceTargetConfig(initTarget)
+      ? {
+          rdsInstanceId: initTarget.rdsInstance,
+          awsClientConfig,
+        }
+      : isRdsClusterTargetConfig(initTarget)
+      ? {
+          rdsClusterId: initTarget.rdsCluster,
+          awsClientConfig,
+        }
+      : isElasticacheRedisClusterTargetConfig(initTarget)
+      ? {
+          elasticacheRedisClusterId: initTarget.elasticacheRedisCluster,
+          awsClientConfig,
+        }
+      : isElasticacheRedisNodeTargetConfig(initTarget)
+      ? {
+          elasticacheRedisNodeId: initTarget.elasticacheRedisNode,
+          awsClientConfig,
+        }
+      : isElasticacheMemcachedClusterTargetConfig(initTarget)
+      ? {
+          elasticacheMemcachedClusterId:
+            initTarget.elasticacheMemcachedCluster,
+          awsClientConfig,
+        }
+      : isElasticacheMemcachedNodeTargetConfig(initTarget)
+      ? {
+          elasticacheMemcachedNodeId: initTarget.elasticacheMemcachedNode,
+          awsClientConfig,
+        }
+      : {
+          customTargetVpcId: initTarget.customTargetVpc,
+          awsClientConfig,
+        },
+    bastionSubnet: initTarget.bastionSubnet,
+    tags: getTagsFromOptions(options)
+  };
+}


### PR DESCRIPTION
## Proposed Changes
This PR adds support for parsing the config file for the basti init command. 

## Related Issues/PRs

## Checklist

- [ ] I cleaned up my code.
- [ ] All the tests and checks passed (`npm run test`).
- [ ] I have added necessary documentation and/or updated existing documentation. <!-- check if not applicable -->
- [ ] I have added or modified tests to cover the changes. <!-- check if not applicable -->