### PR TITLE
Add nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist
 .DS_Store
 .idea
 /.history
+result
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1761672384,
+        "narHash": "sha256-o9KF3DJL7g7iYMZq9SWgfS1BFlNbsm6xplRjVlOCkXI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "08dacfca559e1d7da38f3cf05f1f45ee9bfd213c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,55 @@
+{
+  description = "Basti - Securely connect to AWS resources in private VPCs";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        basti = pkgs.buildNpmPackage {
+          pname = "basti";
+          version = "1.7.2";
+
+          src = self;
+
+          npmDepsHash = "sha256-zxXiutwNEyDNr7OPKb/0fKLXvHRFLdgCsGeBat7tpFk=";
+
+          npmWorkspace = "packages/basti";
+
+          npmBuildScript = "build-src";
+
+          postInstall = ''
+            rm -rf $out/lib/node_modules/*/node_modules/{.bin,basti,basti-cdk,docs}
+            ln -sf ../lib/node_modules/basti-monorepo/bin/run.js $out/bin/basti
+          '';
+
+          meta = with pkgs.lib; {
+            description = "Securely connect to RDS, Elasticache, and other AWS resources in VPCs with no idle cost";
+            homepage = "https://github.com/basti-app/basti";
+            license = licenses.mit;
+            platforms = platforms.unix;
+          };
+        };
+      in
+      {
+        packages.default = basti;
+
+        apps.default = {
+          type = "app";
+          program = "${basti}/bin/basti";
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            basti
+            pkgs.awscli2
+          ];
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -10,10 +10,11 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        packageJson = builtins.fromJSON (builtins.readFile ./packages/basti/package.json);
 
         basti = pkgs.buildNpmPackage {
           pname = "basti";
-          version = "1.7.2";
+          version = packageJson.version;
 
           src = self;
 


### PR DESCRIPTION
## Proposed Changes

Add a nix flake, so I can run `nix run github:basti-app/basti` or add basti to [devenv](https://devenv.sh/) shells, install on NixOS etc.

## Related Issues/PRs
\-