### PR TITLE
Fix Nix Flake's npmDepsHash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
 
           src = self;
 
-          npmDepsHash = "sha256-zxXiutwNEyDNr7OPKb/0fKLXvHRFLdgCsGeBat7tpFk=";
+          npmDepsHash = "sha256-GEh/u5Fg8lVa7e56LG3baujj8JlsLyk2qYwvorniA2I=";
 
           npmWorkspace = "packages/basti";
 


### PR DESCRIPTION
## Proposed Changes

Tried to do `nix flake update` in a repo depending on this flake, and found a hash mismatch — I guess npm modules have been updated at some point since the previous hash. Here's the one that works for me currently.

## Related Issues/PRs

#130

## Checklist

- [x] I cleaned up my code.
- [x] All the tests and checks passed (`npm run test`). <-- n/a, but `npm run test` doesn't work?
- [x] I have added necessary documentation and/or updated existing documentation. <!-- check if not applicable -->
- [x] I have added or modified tests to cover the changes. <!-- check if not applicable -->